### PR TITLE
annotate.py: Change the default to --no-use-repo due to bug (temporary change)

### DIFF
--- a/src/diffannotator/annotate.py
+++ b/src/diffannotator/annotate.py
@@ -1770,7 +1770,7 @@ def from_repo(
         typer.Option(
             help="Retrieve pre-/post-image contents from repo, and use it for lexing"
         )
-    ] = True,
+    ] = False,
 ) -> None:
     """Create annotation data for commits from local Git repository
 


### PR DESCRIPTION
```
Error processing PatchSet <PatchSet: [<PatchedFile: subdir/subfile>]>
at 1 patched file: KeyError(0)
  File "src/diffannotator/annotate.py", line 949, in from_patchset
   patch_annotations.update(annotated_patch_file.process())
  File "src/diffannotator/annotate.py", line 577, in process
    hunk_data = AnnotatedHunk(self, hunk).process()
  File "src/diffannotator/annotate.py", line 688, in process
    tokens_group = self.tokens_for_type(line_type)
  File "src/diffannotator/annotate.py", line 624, in tokens_for_type
    return self.patched_file.hunk_tokens_for_type(line_type, self.hunk)
  File "src/diffannotator/annotate.py", line 556, in hunk_tokens_for_type
    result[hunk_line_no] = tokens_list[line_no - 1]
```

Note that the error is silenced, so the test suite passes (where it should not pass).