### PR TITLE
Experiments: Some new data for comparing PatchScope with HaPy-Bug and Herbold datasets

### DIFF
--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 363,
+   "execution_count": 2,
    "id": "376dce27-af8c-417f-b87f-8bfbc274a48f",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "b56ec732-ef0a-46da-a0ca-2fe4391b31fe",
    "metadata": {},
    "outputs": [],
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d60c1747-dddb-4750-acb1-9c06d7b6ee04",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "511cfc9f-38bd-4d4f-946f-b7b9951ae315",
    "metadata": {},
    "outputs": [
@@ -124,7 +124,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "b98f154b-2041-41f8-bd1d-fe5e441033cd",
    "metadata": {},
    "outputs": [
@@ -145,7 +145,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "7e30759a-5d68-4019-90e5-8b4ecf8099ac",
    "metadata": {},
    "outputs": [],
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "4c04cbe0-1705-4bd7-a7b1-0abeb92585ec",
    "metadata": {},
    "outputs": [],
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "ea5a4918-5514-4f08-af47-dcb8b39dc4bd",
    "metadata": {},
    "outputs": [
@@ -187,7 +187,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "9cd66d15-ace2-4355-b066-dec59e08360c",
    "metadata": {
     "scrolled": true
@@ -253,7 +253,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "96d3dcbd-aaec-44d8-9e4c-5076eb648e92",
    "metadata": {},
    "outputs": [
@@ -278,7 +278,7 @@
        " '-': [{'id': 85, 'type': 'bug(fix)'}]}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "f4192f0d-d1ac-4afe-969f-89bc30e7af6b",
    "metadata": {},
    "outputs": [
@@ -313,7 +313,7 @@
        " '-': []}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "8535cd0f-9f39-4cfd-bb9a-23fdf6c38c3a",
    "metadata": {
     "scrolled": true
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "6177b8fb-0cdc-4942-97a0-6630d62d9ae1",
    "metadata": {},
    "outputs": [],
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "37f19b94-1360-4087-896c-d0f6c632e216",
    "metadata": {},
    "outputs": [
@@ -409,7 +409,7 @@
        "{'rA': 1, 'rB': 1, 'rC': 0, 'rD': 1, 'pA': 2, 'pB': 4, 'pC': 1, 'pD': 3}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "8a80ab8f-dd45-41ae-8e2d-d3ab2d4a6213",
    "metadata": {},
    "outputs": [],
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "1a53474e-d9bb-4837-a39c-7c5c5226f021",
    "metadata": {},
    "outputs": [],
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "f1daa15c-c1b3-45a5-aa8a-3028023e33aa",
    "metadata": {
     "scrolled": true
@@ -11106,7 +11106,7 @@
        "      'beforeChange': []}}]]}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11125,7 +11125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "b0c7cc98-3545-4bd6-8385-9d5ab92b70ee",
    "metadata": {},
    "outputs": [
@@ -11143,7 +11143,7 @@
        " PosixPath('../../data/experiments/HaPy-Bug/cve_blame.csv')]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11155,7 +11155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "08bf7d0f-d85b-4340-96de-f3fde67f31e2",
    "metadata": {},
    "outputs": [
@@ -11164,15 +11164,15 @@
      "output_type": "stream",
      "text": [
       "total 81736\n",
-      "-rw-r--r-- 1 jnareb jnareb  2558150 Nov 30 11:13 bip_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb 50424028 Nov 30 11:13 collective.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb 18222220 Nov 30 11:13 consensus.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb  6895847 Nov 30 11:13 crawl_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb  5385717 Nov 30 11:13 cve_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb      939 Nov 30 11:13 hapybug_line_callback_func.py\n",
-      "-rw-r--r-- 1 jnareb jnareb    15132 Nov 30 11:13 repositories.json\n",
-      "-rwxr-xr-x 1 jnareb jnareb    26627 Nov 30 11:13 \u001b[0m\u001b[01;32mrun_annotation_bugsinpy_repos.sh\u001b[0m*\n",
-      "-rwxr-xr-x 1 jnareb jnareb   150891 Nov 30 11:13 \u001b[01;32mrun_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "-rw-r--r-- 1 jnareb jnareb  2558150 Dec  1 01:30 bip_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb 50424028 Dec  1 01:30 collective.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb 18222220 Dec  1 01:30 consensus.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb  6895847 Dec  1 01:30 crawl_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb  5385717 Dec  1 01:30 cve_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb      939 Dec  1 01:30 hapybug_line_callback_func.py\n",
+      "-rw-r--r-- 1 jnareb jnareb    15132 Dec  1 01:30 repositories.json\n",
+      "-rwxr-xr-x 1 jnareb jnareb    26627 Dec  1 01:30 \u001b[0m\u001b[01;32mrun_annotation_bugsinpy_repos.sh\u001b[0m*\n",
+      "-rwxr-xr-x 1 jnareb jnareb   150891 Dec  1 01:30 \u001b[01;32mrun_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -11182,7 +11182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "0058312b-27c4-465b-b67f-ccbaac7602dc",
    "metadata": {},
    "outputs": [
@@ -11192,7 +11192,7 @@
        "PosixPath('../../data/experiments/HaPy-Bug/collective.csv')"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11204,7 +11204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "c3efef45-8da3-4b42-99df-6b7c80e88d02",
    "metadata": {},
    "outputs": [
@@ -11462,7 +11462,7 @@
        "[391918 rows x 11 columns]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11475,7 +11475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "9ffdc348-5788-4d32-9616-6ffdfd32b86e",
    "metadata": {},
    "outputs": [
@@ -11489,7 +11489,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11500,7 +11500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "c80eb300-885a-48b6-b8b3-cbc9db3a6009",
    "metadata": {},
    "outputs": [
@@ -11514,7 +11514,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11526,7 +11526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1148,
+   "execution_count": 25,
    "id": "306a655e-b58a-401d-b311-8ba0f078d416",
    "metadata": {},
    "outputs": [
@@ -11548,7 +11548,7 @@
        "Name: id, Length: 496, dtype: object"
       ]
      },
-     "execution_count": 1148,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11559,7 +11559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1149,
+   "execution_count": 26,
    "id": "e525e93d-8f11-43d4-8be7-ea13de7d82be",
    "metadata": {},
    "outputs": [
@@ -11569,7 +11569,7 @@
        "(496,)"
       ]
      },
-     "execution_count": 1149,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11617,7 +11617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "6efdb59c-6692-4386-95fc-729188f276da",
    "metadata": {},
    "outputs": [],
@@ -11627,7 +11627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "f21d9a51-5f22-4dfb-939e-b1a00a031ef2",
    "metadata": {
     "scrolled": true
@@ -11746,7 +11746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "a4d047c6-6021-4d8a-8c43-d89e4ec0c9a9",
    "metadata": {},
    "outputs": [
@@ -11764,7 +11764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "ea24fca3-7799-4906-ae98-405a875009d5",
    "metadata": {},
    "outputs": [
@@ -11774,7 +11774,7 @@
        "PosixPath('/mnt/data/python-diff-annotator/example_annotations/HaPy-Bug/bugsinpy-dataset/cookiecutter-1/annotation/7f6804c4953a18386809f11faf4d86898570debc.v2.json')"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11789,7 +11789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "ff3e8c8e-435b-40ed-8e73-4bda1cbc85d9",
    "metadata": {},
    "outputs": [
@@ -11799,7 +11799,7 @@
        "dict"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11813,7 +11813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "id": "94f4ced7-0846-4055-a715-31f5102ac3c0",
    "metadata": {},
    "outputs": [
@@ -11823,7 +11823,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11834,7 +11834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "40633644-7a46-415c-baa4-f570f81dd28e",
    "metadata": {},
    "outputs": [
@@ -11844,7 +11844,7 @@
        "{'id': '7f6804c4953a18386809f11faf4d86898570debc'}"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11855,7 +11855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "id": "78053ed0-e6d6-4ac4-a31b-607c549331e6",
    "metadata": {},
    "outputs": [
@@ -11876,7 +11876,7 @@
        " 'n_add': 14}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11887,7 +11887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "id": "c4dcf143-0652-4fdb-8864-b23f5809fc56",
    "metadata": {},
    "outputs": [
@@ -11897,7 +11897,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11908,7 +11908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "id": "6656a404-ffc0-462a-9b61-a7af3c50275b",
    "metadata": {
     "scrolled": true
@@ -11963,7 +11963,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11998,7 +11998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "id": "d09aa5d4-5887-4d3e-8202-04aec95d6da5",
    "metadata": {},
    "outputs": [
@@ -12008,7 +12008,7 @@
        "True"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12020,7 +12020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "id": "ce20ae51-c5b0-4314-9b8c-6f88856a5bd1",
    "metadata": {},
    "outputs": [
@@ -12062,7 +12062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "id": "1308ac24-045a-4d8c-a711-b599e6862c64",
    "metadata": {},
    "outputs": [],
@@ -12072,7 +12072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "id": "665af095-2dc3-49c5-a0dc-bd7efd3dc782",
    "metadata": {},
    "outputs": [
@@ -12089,7 +12089,7 @@
        "  'cookiecutter-4']}"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12115,7 +12115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "id": "489b0f11-5954-4dfc-8560-39d97c0777b4",
    "metadata": {},
    "outputs": [
@@ -12125,7 +12125,7 @@
        "dict_keys(['pandas', 'thefuck', 'tornado', 'black', 'youtube-dl', 'spacy', 'keras', 'ansible', 'scrapy', 'fastapi', 'luigi', 'matplotlib', 'tqdm', 'sanic', 'cookiecutter', 'httpie', 'PySnooper'])"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12144,7 +12144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "id": "aa8d5632-c6d2-4fdb-97b0-b450e3cd7a3d",
    "metadata": {},
    "outputs": [
@@ -12152,7 +12152,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 jnareb jnareb 15132 Nov 30 11:13 ../../data/experiments/HaPy-Bug/repositories.json\n"
+      "-rw-r--r-- 1 jnareb jnareb 15132 Dec  1 01:30 ../../data/experiments/HaPy-Bug/repositories.json\n"
      ]
     }
    ],
@@ -12163,7 +12163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "id": "8cadb7e1-87d1-4e3c-9774-874cea0e5a02",
    "metadata": {},
    "outputs": [
@@ -12181,7 +12181,7 @@
        "  'repository_path': '/mnt/data/python_bug_localization_data/repositories/black'}]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12195,7 +12195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "id": "5574e2ee-4653-46d3-877e-7543f3ddb663",
    "metadata": {},
    "outputs": [
@@ -12206,7 +12206,7 @@
        " 'path': '/mnt/data/python_bug_localization_data/repositories/cookiecutter'}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12230,7 +12230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "id": "8a4ad948-3eb9-407c-9771-24022314d20d",
    "metadata": {},
    "outputs": [],
@@ -12240,7 +12240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 46,
    "id": "a442f585-17a9-4e72-ac16-311f3b2d5521",
    "metadata": {
     "scrolled": true
@@ -12267,7 +12267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 47,
    "id": "16eb6420-8f9f-498f-b907-310a84144a51",
    "metadata": {
     "scrolled": true
@@ -12417,7 +12417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 48,
    "id": "ef6f6d45-8b96-4ccf-9f99-0f117f3eb2ee",
    "metadata": {},
    "outputs": [],
@@ -12428,7 +12428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 49,
    "id": "0cee0e4c-faf1-43ec-a5d1-71babf93be4d",
    "metadata": {},
    "outputs": [
@@ -12464,7 +12464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 50,
    "id": "3a6beef5-c325-4e92-9a18-60e4cc314339",
    "metadata": {},
    "outputs": [
@@ -12485,7 +12485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 51,
    "id": "51cf8b16-4a5b-43d5-a886-18aa5f7fdf90",
    "metadata": {},
    "outputs": [
@@ -12495,7 +12495,7 @@
        "PosixPath('/mnt/data/python-diff-annotator/example_annotations/bugsinpy-from-repo/cookiecutter/7f6804c4953a18386809f11faf4d86898570debc.v2.json')"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12507,7 +12507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 52,
    "id": "3204ff1a-c4ad-4684-976d-d6fd041be709",
    "metadata": {},
    "outputs": [
@@ -12517,7 +12517,7 @@
        "dict"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12531,7 +12531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 53,
    "id": "934cffd9-473e-4e37-a90b-823cd8cc5b20",
    "metadata": {},
    "outputs": [
@@ -12541,7 +12541,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12560,7 +12560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 54,
    "id": "0e9e1736-5d31-4ac0-bb25-8fd4182ea815",
    "metadata": {},
    "outputs": [
@@ -12583,7 +12583,7 @@
        " 'message': 'Fix default values being loaded with wrong encoding on Windows (#1414)\\n\\nExplicitly set the encoding to utf-8 when reading the context file to\\nensure values are correctly loaded.\\n\\nCo-authored-by: Andrey Shpak <insspb@users.noreply.github.com>\\n'}"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12594,7 +12594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 55,
    "id": "9eb4e022-ece7-4af6-9164-55fbe5bd73ea",
    "metadata": {},
    "outputs": [
@@ -12615,7 +12615,7 @@
        " 'n_add': 14}"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12626,7 +12626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 56,
    "id": "56640641-921c-4930-bf83-8cf9bf2e88ba",
    "metadata": {},
    "outputs": [
@@ -12636,7 +12636,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12647,7 +12647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 57,
    "id": "7a044ee7-ee05-4832-9a53-9f49cbb21ebb",
    "metadata": {
     "scrolled": true
@@ -12702,7 +12702,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12721,7 +12721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 58,
    "id": "c0eed77f-d269-4983-8288-4c0e8d97e085",
    "metadata": {},
    "outputs": [],
@@ -12731,7 +12731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 59,
    "id": "589885ec-e18f-408c-84ba-b8f9a4753905",
    "metadata": {},
    "outputs": [
@@ -12739,7 +12739,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rwxr-xr-x 1 jnareb jnareb 25506 Nov 29 12:15 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "-rwxr-xr-x 1 jnareb jnareb 429 Nov 30 20:12 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -12749,7 +12749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 60,
    "id": "66e2acc9-66c7-42b0-a622-51116874f77e",
    "metadata": {},
    "outputs": [],
@@ -12759,7 +12759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 61,
    "id": "a1ce811e-dc1c-4592-b764-6996f3a3a314",
    "metadata": {},
    "outputs": [],
@@ -12769,7 +12769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 62,
    "id": "5e2faf0a-de56-40be-b159-fa2e8ec2fbbf",
    "metadata": {},
    "outputs": [],
@@ -12794,7 +12794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 63,
    "id": "1acd39f7-7db6-4f36-b214-b27eeb6496e3",
    "metadata": {},
    "outputs": [
@@ -12802,7 +12802,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 jnareb jnareb 939 Nov 30 11:13 ../../data/experiments/HaPy-Bug/hapybug_line_callback_func.py\n"
+      "-rw-r--r-- 1 jnareb jnareb 939 Dec  1 01:30 ../../data/experiments/HaPy-Bug/hapybug_line_callback_func.py\n"
      ]
     }
    ],
@@ -12812,7 +12812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 64,
    "id": "24ad4929-7aad-40b2-830b-9b22ca324ef4",
    "metadata": {},
    "outputs": [
@@ -12859,7 +12859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 65,
    "id": "4ae741f5-b470-4bf6-b203-afa236316f49",
    "metadata": {},
    "outputs": [
@@ -12867,7 +12867,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rwxr-xr-x 1 jnareb jnareb 429 Nov 30 20:12 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "-rwxr-xr-x 1 jnareb jnareb 429 Dec  5 09:35 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -12885,7 +12885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 66,
    "id": "776ce2ef-9c90-480d-a346-6a92706c1960",
    "metadata": {},
    "outputs": [
@@ -12897,7 +12897,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12908,7 +12908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 67,
    "id": "2d9039fb-08c3-4316-9a17-5f2fe05a35a3",
    "metadata": {},
    "outputs": [
@@ -12929,7 +12929,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12940,7 +12940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 68,
    "id": "45d5c707-d3a8-41c2-bafa-ca446d783b2c",
    "metadata": {},
    "outputs": [
@@ -13085,7 +13085,7 @@
        "4  programming   afterChange   103   bug(fix)   U2  False  cve  CVE-2020-10289  "
       ]
      },
-     "execution_count": 65,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13096,7 +13096,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 69,
    "id": "f92d0c71-80ef-4b81-8002-60728afed203",
    "metadata": {},
    "outputs": [
@@ -13110,7 +13110,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13121,7 +13121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 70,
    "id": "a2a00259-07f6-4249-9185-9a313ff5dbd4",
    "metadata": {},
    "outputs": [
@@ -13379,7 +13379,7 @@
        "[60194 rows x 11 columns]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13391,7 +13391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 71,
    "id": "3612172f-5aa6-450b-bba3-69a3f40f055d",
    "metadata": {},
    "outputs": [
@@ -13405,7 +13405,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13416,7 +13416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 72,
    "id": "639ae27a-fe99-4ecb-9ba8-fd22ac6bc948",
    "metadata": {},
    "outputs": [
@@ -13756,7 +13756,7 @@
        "145624   121           test   U3  False  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 69,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13772,7 +13772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 73,
    "id": "26469e00-6729-4f5e-8249-df739ee917f9",
    "metadata": {},
    "outputs": [
@@ -13782,7 +13782,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13793,7 +13793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 74,
    "id": "dec16177-c463-46ca-82dc-ad1c2ba560a3",
    "metadata": {
     "scrolled": true
@@ -13848,7 +13848,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13859,7 +13859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 75,
    "id": "988fd36f-282e-4084-a778-61e956c9c001",
    "metadata": {
     "scrolled": true
@@ -13910,7 +13910,7 @@
        "  'bug': 'cookiecutter-1'}]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13945,7 +13945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 76,
    "id": "f8d8fe49-7550-4184-afbc-cedd8f4eae51",
    "metadata": {},
    "outputs": [
@@ -14199,7 +14199,7 @@
        "15         test   afterChange   121       test  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 73,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14211,7 +14211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 77,
    "id": "9a4f56eb-b88a-4f60-8e5b-a2c55151a450",
    "metadata": {},
    "outputs": [
@@ -14322,7 +14322,7 @@
        "4         test   afterChange     3       test  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 74,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14333,7 +14333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 78,
    "id": "f21eea10-bce7-4b9c-a3d5-90d07b7ac3e8",
    "metadata": {},
    "outputs": [
@@ -14486,7 +14486,7 @@
        "145613     3       test   U3  False  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 75,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14505,7 +14505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 79,
    "id": "063cda3e-5fb4-41c4-8c42-0acc689d95b2",
    "metadata": {},
    "outputs": [
@@ -14644,7 +14644,7 @@
        "145613     3       test  "
       ]
      },
-     "execution_count": 76,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14656,7 +14656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 80,
    "id": "55027f0f-5653-4b23-b419-e644556f3dfb",
    "metadata": {},
    "outputs": [
@@ -14755,7 +14755,7 @@
        "4   afterChange     3       test  "
       ]
      },
-     "execution_count": 77,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14767,7 +14767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 81,
    "id": "40985c6c-ff03-4b36-8ea5-0e4d11c1ff18",
    "metadata": {},
    "outputs": [
@@ -14909,7 +14909,7 @@
        "4     3            test         test            test             both  "
       ]
      },
-     "execution_count": 78,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14925,7 +14925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 82,
    "id": "3ff9be8a-3e4b-423b-abf9-98378a1a6e65",
    "metadata": {},
    "outputs": [
@@ -15086,7 +15086,7 @@
        "4     True           True  "
       ]
      },
-     "execution_count": 79,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15100,7 +15100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 83,
    "id": "0b7ac5e8-dc4c-4c03-9eaf-b1b261742bfb",
    "metadata": {},
    "outputs": [
@@ -15113,7 +15113,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15124,7 +15124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 84,
    "id": "c6c193aa-8714-4b0c-81fd-e03690dc0fcb",
    "metadata": {},
    "outputs": [
@@ -15198,7 +15198,7 @@
        "6             both     True          False  "
       ]
      },
-     "execution_count": 81,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15217,7 +15217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 85,
    "id": "aa73bbae-279a-44d2-ab36-dbc24aa51de1",
    "metadata": {},
    "outputs": [
@@ -15230,7 +15230,7 @@
        " '457a1a4e862aab4102b644ff1d2b2e2b5a766b3c': 'cookiecutter-4'}"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15254,7 +15254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 86,
    "id": "f484b678-8001-49bb-97d8-569fc4f8fdd2",
    "metadata": {},
    "outputs": [
@@ -15264,7 +15264,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/bugsinpy-from-repo/'"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15275,7 +15275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 87,
    "id": "773c96b2-8c4b-4e10-adaf-e26801cc3cf2",
    "metadata": {
     "scrolled": true
@@ -15371,7 +15371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 88,
    "id": "6f776d5a-5d68-4af5-a733-11598fba8dd8",
    "metadata": {
     "scrolled": true
@@ -15427,7 +15427,7 @@
        "  'annotation': 'bug(fix)'}]"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15438,372 +15438,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "id": "49bbe5b6-49dc-4685-aafa-f0df20cead10",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>ds</th>\n",
-       "      <th>bug</th>\n",
-       "      <th>sha</th>\n",
-       "      <th>file</th>\n",
-       "      <th>fcat</th>\n",
-       "      <th>image</th>\n",
-       "      <th>line</th>\n",
-       "      <th>annotation</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>bugs-in-py_httpie-1</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>httpie-1</td>\n",
-       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
-       "      <td>CHANGELOG.rst</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>30</td>\n",
-       "      <td>documentation</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>bugs-in-py_httpie-1</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>httpie-1</td>\n",
-       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
-       "      <td>httpie/downloads.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>beforeChange</td>\n",
-       "      <td>142</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>bugs-in-py_httpie-1</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>httpie-1</td>\n",
-       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
-       "      <td>httpie/downloads.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>beforeChange</td>\n",
-       "      <td>143</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>bugs-in-py_httpie-1</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>httpie-1</td>\n",
-       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
-       "      <td>httpie/downloads.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>10</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>bugs-in-py_httpie-1</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>httpie-1</td>\n",
-       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
-       "      <td>httpie/downloads.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>139</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19885</th>\n",
-       "      <td>bugs-in-py_thefuck-9</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>thefuck-9</td>\n",
-       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
-       "      <td>thefuck/rules/git_push.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>27</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19886</th>\n",
-       "      <td>bugs-in-py_thefuck-9</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>thefuck-9</td>\n",
-       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
-       "      <td>thefuck/rules/git_push.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>28</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19887</th>\n",
-       "      <td>bugs-in-py_thefuck-9</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>thefuck-9</td>\n",
-       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
-       "      <td>thefuck/rules/git_push.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>29</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19888</th>\n",
-       "      <td>bugs-in-py_thefuck-9</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>thefuck-9</td>\n",
-       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
-       "      <td>thefuck/rules/git_push.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>30</td>\n",
-       "      <td>documentation</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19889</th>\n",
-       "      <td>bugs-in-py_thefuck-9</td>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>thefuck-9</td>\n",
-       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
-       "      <td>thefuck/rules/git_push.py</td>\n",
-       "      <td>programming</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>31</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>19890 rows × 9 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                         id          ds        bug  \\\n",
-       "0       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
-       "1       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
-       "2       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
-       "3       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
-       "4       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
-       "...                     ...         ...        ...   \n",
-       "19885  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
-       "19886  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
-       "19887  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
-       "19888  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
-       "19889  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
-       "\n",
-       "                                            sha                       file  \\\n",
-       "0      5300b0b490b8db48fac30b5e32164be93dc574b7              CHANGELOG.rst   \n",
-       "1      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
-       "2      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
-       "3      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
-       "4      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
-       "...                                         ...                        ...   \n",
-       "19885  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
-       "19886  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
-       "19887  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
-       "19888  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
-       "19889  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
-       "\n",
-       "                fcat         image  line     annotation  \n",
-       "0      documentation   afterChange    30  documentation  \n",
-       "1        programming  beforeChange   142       bug(fix)  \n",
-       "2        programming  beforeChange   143       bug(fix)  \n",
-       "3        programming   afterChange    10       bug(fix)  \n",
-       "4        programming   afterChange   139       bug(fix)  \n",
-       "...              ...           ...   ...            ...  \n",
-       "19885    programming   afterChange    27       bug(fix)  \n",
-       "19886    programming   afterChange    28       bug(fix)  \n",
-       "19887    programming   afterChange    29       bug(fix)  \n",
-       "19888    programming   afterChange    30  documentation  \n",
-       "19889    programming   afterChange    31       bug(fix)  \n",
-       "\n",
-       "[19890 rows x 9 columns]"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from_repos_df = pd.DataFrame.from_records(records_from_repos)\n",
-    "from_repos_df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ffd2fe6-3131-45e9-a286-a9f8889f2b5d",
-   "metadata": {},
-   "source": [
-    "#### for hapy_bip-from-repo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 87,
-   "id": "1f396ca7-a5ea-43df-b6e7-e61ac24d82a7",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/mnt/data/python-diff-annotator/example_annotations/hapy_bip-from-repo'"
-      ]
-     },
-     "execution_count": 87,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "bugsinpy_annotated_hapy_bip_dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 88,
-   "id": "e950fd34-fc63-42cf-bd35-67367e436a86",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "httpie  5 commits, 13 changed files, 145 changed lines\n",
-      "PySnooper  3 commits, 8 changed files, 117 changed lines\n",
-      "keras  45 commits, 107 changed files, 2122 changed lines\n",
-      "pandas  168 commits, 582 changed files, 7464 changed lines\n",
-      "spacy  10 commits, 29 changed files, 270 changed lines\n",
-      "tornado  16 commits, 39 changed files, 575 changed lines\n",
-      "scrapy  40 commits, 98 changed files, 1196 changed lines\n",
-      "youtube-dl  43 commits, 100 changed files, 702 changed lines\n",
-      "matplotlib  27 commits, 64 changed files, 714 changed lines\n",
-      "black  23 commits, 74 changed files, 1638 changed lines\n",
-      "sanic  5 commits, 14 changed files, 207 changed lines\n",
-      "cookiecutter  4 commits, 11 changed files, 108 changed lines\n",
-      "fastapi  16 commits, 43 changed files, 1415 changed lines\n",
-      "luigi  33 commits, 70 changed files, 1308 changed lines\n",
-      "tqdm  9 commits, 19 changed files, 215 changed lines\n",
-      "ansible  18 commits, 54 changed files, 803 changed lines\n",
-      "thefuck  32 commits, 72 changed files, 891 changed lines\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'id': 'bugs-in-py_httpie-1',\n",
-       "  'ds': 'bugs-in-py',\n",
-       "  'bug': 'httpie-1',\n",
-       "  'sha': '5300b0b490b8db48fac30b5e32164be93dc574b7',\n",
-       "  'file': 'CHANGELOG.rst',\n",
-       "  'fcat': 'documentation',\n",
-       "  'image': 'afterChange',\n",
-       "  'line': 30,\n",
-       "  'annotation': 'documentation'},\n",
-       " {'id': 'bugs-in-py_httpie-1',\n",
-       "  'ds': 'bugs-in-py',\n",
-       "  'bug': 'httpie-1',\n",
-       "  'sha': '5300b0b490b8db48fac30b5e32164be93dc574b7',\n",
-       "  'file': 'httpie/downloads.py',\n",
-       "  'fcat': 'programming',\n",
-       "  'image': 'beforeChange',\n",
-       "  'line': 142,\n",
-       "  'annotation': 'bug(fix)'}]"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "records_from_repos_2 = []\n",
-    "\n",
-    "dataset = 'bugs-in-py'\n",
-    "\n",
-    "for subdir in Path(bugsinpy_annotated_hapy_bip_dir).iterdir():\n",
-    "    print(f\"{subdir.name}\", end='')\n",
-    "    count = 0\n",
-    "    n_files = 0\n",
-    "    n_lines = 0\n",
-    "\n",
-    "    for json_file in subdir.glob('*.json'):\n",
-    "        sha = json_file.name.split('.', maxsplit=1)[0]\n",
-    "        bug = sha_to_bug[sha]\n",
-    "        #print(f\"  {json_file.name} -> {sha=}, {bug=}\")\n",
-    "        count += 1\n",
-    "\n",
-    "        with open(json_file, mode='r') as json_fp:\n",
-    "            json_data = json.load(json_fp)\n",
-    "\n",
-    "        for patched_file, file_data in json_data['changes'].items():\n",
-    "            if patched_file == '/dev/null':\n",
-    "                continue\n",
-    "\n",
-    "            n_files += 1\n",
-    "            \n",
-    "            for pm in list(\"-+\"):\n",
-    "                if pm not in file_data:\n",
-    "                    continue\n",
-    "\n",
-    "                for line_data in file_data[pm]:\n",
-    "                    n_lines += 1\n",
-    "                    records_from_repos_2.append({\n",
-    "                        'id': f\"{dataset}_{bug}\",\n",
-    "                        'ds': dataset,\n",
-    "                        'bug': bug,\n",
-    "                        'sha': sha,\n",
-    "                        'file': patched_file,\n",
-    "                        'fcat': file_data['purpose'],\n",
-    "                        'image': 'beforeChange' if pm == '-' else 'afterChange',\n",
-    "                        'line': line_data['file_line_no'],\n",
-    "                        'annotation': line_data['type'],\n",
-    "                    })\n",
-    "\n",
-    "    print(f\"  {count} commits, {n_files} changed files, {n_lines} changed lines\")\n",
-    "\n",
-    "records_from_repos_2[:2]"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 89,
-   "id": "91643372-cad0-4528-9c03-49456bba1e74",
+   "id": "49bbe5b6-49dc-4685-aafa-f0df20cead10",
    "metadata": {},
    "outputs": [
     {
@@ -16025,13 +15661,377 @@
     }
    ],
    "source": [
+    "from_repos_df = pd.DataFrame.from_records(records_from_repos)\n",
+    "from_repos_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ffd2fe6-3131-45e9-a286-a9f8889f2b5d",
+   "metadata": {},
+   "source": [
+    "#### for hapy_bip-from-repo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "1f396ca7-a5ea-43df-b6e7-e61ac24d82a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/mnt/data/python-diff-annotator/example_annotations/hapy_bip-from-repo'"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bugsinpy_annotated_hapy_bip_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "e950fd34-fc63-42cf-bd35-67367e436a86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "httpie  5 commits, 13 changed files, 145 changed lines\n",
+      "PySnooper  3 commits, 8 changed files, 117 changed lines\n",
+      "keras  45 commits, 107 changed files, 2122 changed lines\n",
+      "pandas  168 commits, 582 changed files, 7464 changed lines\n",
+      "spacy  10 commits, 29 changed files, 270 changed lines\n",
+      "tornado  16 commits, 39 changed files, 575 changed lines\n",
+      "scrapy  40 commits, 98 changed files, 1196 changed lines\n",
+      "youtube-dl  43 commits, 100 changed files, 702 changed lines\n",
+      "matplotlib  27 commits, 64 changed files, 714 changed lines\n",
+      "black  23 commits, 74 changed files, 1638 changed lines\n",
+      "sanic  5 commits, 14 changed files, 207 changed lines\n",
+      "cookiecutter  4 commits, 11 changed files, 108 changed lines\n",
+      "fastapi  16 commits, 43 changed files, 1415 changed lines\n",
+      "luigi  33 commits, 70 changed files, 1308 changed lines\n",
+      "tqdm  9 commits, 19 changed files, 215 changed lines\n",
+      "ansible  18 commits, 54 changed files, 803 changed lines\n",
+      "thefuck  32 commits, 72 changed files, 891 changed lines\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'bugs-in-py_httpie-1',\n",
+       "  'ds': 'bugs-in-py',\n",
+       "  'bug': 'httpie-1',\n",
+       "  'sha': '5300b0b490b8db48fac30b5e32164be93dc574b7',\n",
+       "  'file': 'CHANGELOG.rst',\n",
+       "  'fcat': 'documentation',\n",
+       "  'image': 'afterChange',\n",
+       "  'line': 30,\n",
+       "  'annotation': 'documentation'},\n",
+       " {'id': 'bugs-in-py_httpie-1',\n",
+       "  'ds': 'bugs-in-py',\n",
+       "  'bug': 'httpie-1',\n",
+       "  'sha': '5300b0b490b8db48fac30b5e32164be93dc574b7',\n",
+       "  'file': 'httpie/downloads.py',\n",
+       "  'fcat': 'programming',\n",
+       "  'image': 'beforeChange',\n",
+       "  'line': 142,\n",
+       "  'annotation': 'bug(fix)'}]"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "records_from_repos_2 = []\n",
+    "\n",
+    "dataset = 'bugs-in-py'\n",
+    "\n",
+    "for subdir in Path(bugsinpy_annotated_hapy_bip_dir).iterdir():\n",
+    "    print(f\"{subdir.name}\", end='')\n",
+    "    count = 0\n",
+    "    n_files = 0\n",
+    "    n_lines = 0\n",
+    "\n",
+    "    for json_file in subdir.glob('*.json'):\n",
+    "        sha = json_file.name.split('.', maxsplit=1)[0]\n",
+    "        bug = sha_to_bug[sha]\n",
+    "        #print(f\"  {json_file.name} -> {sha=}, {bug=}\")\n",
+    "        count += 1\n",
+    "\n",
+    "        with open(json_file, mode='r') as json_fp:\n",
+    "            json_data = json.load(json_fp)\n",
+    "\n",
+    "        for patched_file, file_data in json_data['changes'].items():\n",
+    "            if patched_file == '/dev/null':\n",
+    "                continue\n",
+    "\n",
+    "            n_files += 1\n",
+    "            \n",
+    "            for pm in list(\"-+\"):\n",
+    "                if pm not in file_data:\n",
+    "                    continue\n",
+    "\n",
+    "                for line_data in file_data[pm]:\n",
+    "                    n_lines += 1\n",
+    "                    records_from_repos_2.append({\n",
+    "                        'id': f\"{dataset}_{bug}\",\n",
+    "                        'ds': dataset,\n",
+    "                        'bug': bug,\n",
+    "                        'sha': sha,\n",
+    "                        'file': patched_file,\n",
+    "                        'fcat': file_data['purpose'],\n",
+    "                        'image': 'beforeChange' if pm == '-' else 'afterChange',\n",
+    "                        'line': line_data['file_line_no'],\n",
+    "                        'annotation': line_data['type'],\n",
+    "                    })\n",
+    "\n",
+    "    print(f\"  {count} commits, {n_files} changed files, {n_lines} changed lines\")\n",
+    "\n",
+    "records_from_repos_2[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "91643372-cad0-4528-9c03-49456bba1e74",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>bug</th>\n",
+       "      <th>sha</th>\n",
+       "      <th>file</th>\n",
+       "      <th>fcat</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bugs-in-py_httpie-1</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>httpie-1</td>\n",
+       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
+       "      <td>CHANGELOG.rst</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>30</td>\n",
+       "      <td>documentation</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>bugs-in-py_httpie-1</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>httpie-1</td>\n",
+       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
+       "      <td>httpie/downloads.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>142</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>bugs-in-py_httpie-1</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>httpie-1</td>\n",
+       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
+       "      <td>httpie/downloads.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>143</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>bugs-in-py_httpie-1</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>httpie-1</td>\n",
+       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
+       "      <td>httpie/downloads.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>10</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>bugs-in-py_httpie-1</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>httpie-1</td>\n",
+       "      <td>5300b0b490b8db48fac30b5e32164be93dc574b7</td>\n",
+       "      <td>httpie/downloads.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>139</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19885</th>\n",
+       "      <td>bugs-in-py_thefuck-9</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>thefuck-9</td>\n",
+       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
+       "      <td>thefuck/rules/git_push.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>27</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19886</th>\n",
+       "      <td>bugs-in-py_thefuck-9</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>thefuck-9</td>\n",
+       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
+       "      <td>thefuck/rules/git_push.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>28</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19887</th>\n",
+       "      <td>bugs-in-py_thefuck-9</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>thefuck-9</td>\n",
+       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
+       "      <td>thefuck/rules/git_push.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>29</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19888</th>\n",
+       "      <td>bugs-in-py_thefuck-9</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>thefuck-9</td>\n",
+       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
+       "      <td>thefuck/rules/git_push.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>30</td>\n",
+       "      <td>documentation</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19889</th>\n",
+       "      <td>bugs-in-py_thefuck-9</td>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>thefuck-9</td>\n",
+       "      <td>feb36ede5c518fdc3b6eddf945b2d8b1e2294d15</td>\n",
+       "      <td>thefuck/rules/git_push.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>31</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>19890 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         id          ds        bug  \\\n",
+       "0       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
+       "1       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
+       "2       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
+       "3       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
+       "4       bugs-in-py_httpie-1  bugs-in-py   httpie-1   \n",
+       "...                     ...         ...        ...   \n",
+       "19885  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
+       "19886  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
+       "19887  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
+       "19888  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
+       "19889  bugs-in-py_thefuck-9  bugs-in-py  thefuck-9   \n",
+       "\n",
+       "                                            sha                       file  \\\n",
+       "0      5300b0b490b8db48fac30b5e32164be93dc574b7              CHANGELOG.rst   \n",
+       "1      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
+       "2      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
+       "3      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
+       "4      5300b0b490b8db48fac30b5e32164be93dc574b7        httpie/downloads.py   \n",
+       "...                                         ...                        ...   \n",
+       "19885  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
+       "19886  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
+       "19887  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
+       "19888  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
+       "19889  feb36ede5c518fdc3b6eddf945b2d8b1e2294d15  thefuck/rules/git_push.py   \n",
+       "\n",
+       "                fcat         image  line     annotation  \n",
+       "0      documentation   afterChange    30  documentation  \n",
+       "1        programming  beforeChange   142       bug(fix)  \n",
+       "2        programming  beforeChange   143       bug(fix)  \n",
+       "3        programming   afterChange    10       bug(fix)  \n",
+       "4        programming   afterChange   139       bug(fix)  \n",
+       "...              ...           ...   ...            ...  \n",
+       "19885    programming   afterChange    27       bug(fix)  \n",
+       "19886    programming   afterChange    28       bug(fix)  \n",
+       "19887    programming   afterChange    29       bug(fix)  \n",
+       "19888    programming   afterChange    30  documentation  \n",
+       "19889    programming   afterChange    31       bug(fix)  \n",
+       "\n",
+       "[19890 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "hapy_bip_from_repos_df = pd.DataFrame.from_records(records_from_repos_2)\n",
     "hapy_bip_from_repos_df"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 93,
    "id": "efc21569-d013-4f22-8d8d-ece540c832d9",
    "metadata": {},
    "outputs": [
@@ -16045,7 +16045,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16064,7 +16064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 94,
    "id": "f6ee6919-271e-4a84-85ed-aca24a94572d",
    "metadata": {},
    "outputs": [
@@ -16074,7 +16074,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/HaPy-Bug_bip/bugsinpy-dataset'"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16086,7 +16086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 95,
    "id": "38abed93-188a-4282-8da0-dc89062f634b",
    "metadata": {
     "scrolled": true
@@ -16650,7 +16650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 96,
    "id": "6ab60bf7-c64f-4821-8e93-782383655d88",
    "metadata": {},
    "outputs": [
@@ -16677,7 +16677,7 @@
        "  'annotation': 'bug(fix)'}]"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16688,7 +16688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 97,
    "id": "bb78bc40-7e7d-4d2f-9c58-6c05bb180d98",
    "metadata": {},
    "outputs": [
@@ -16905,7 +16905,7 @@
        "[20268 rows x 9 columns]"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16917,7 +16917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 98,
    "id": "511a1d2a-a127-481a-a424-ee973201f7d7",
    "metadata": {},
    "outputs": [
@@ -16931,7 +16931,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16950,7 +16950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 99,
    "id": "e052c8c0-df6e-44aa-bf3f-7749d7d5462e",
    "metadata": {},
    "outputs": [
@@ -17208,7 +17208,7 @@
        "[195965 rows x 11 columns]"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17219,7 +17219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 100,
    "id": "0472926e-e65d-4dbf-8dd7-6ba6b817874d",
    "metadata": {},
    "outputs": [
@@ -17233,7 +17233,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17244,7 +17244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 101,
    "id": "09a46ed5-25a2-4652-a276-7d4f3b93c8c7",
    "metadata": {},
    "outputs": [
@@ -17502,7 +17502,7 @@
        "[60194 rows x 11 columns]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17514,7 +17514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 102,
    "id": "c41a3d7b-9132-4462-b5d6-5755a7aaf429",
    "metadata": {},
    "outputs": [
@@ -17645,7 +17645,7 @@
        "16418         test   afterChange    51           test  "
       ]
      },
-     "execution_count": 99,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17657,7 +17657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 103,
    "id": "ecf309c1-4f94-4e3f-9d17-2e0a3a7d07b0",
    "metadata": {},
    "outputs": [
@@ -17768,7 +17768,7 @@
        "4  httpie/downloads.py    programming   afterChange   139       bug(fix)  "
       ]
      },
-     "execution_count": 100,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17788,7 +17788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 104,
    "id": "5472a07a-c2be-4f20-a265-8fa1afeeaa1a",
    "metadata": {},
    "outputs": [
@@ -17942,7 +17942,7 @@
        "4                bug(fix)        bug(fix)     False           False  "
       ]
      },
-     "execution_count": 101,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17968,7 +17968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1150,
+   "execution_count": 105,
    "id": "49445847-888b-4859-a042-3beb9e8c55b7",
    "metadata": {},
    "outputs": [
@@ -17982,7 +17982,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 1150,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17993,7 +17993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 106,
    "id": "a32355ba-504e-41ca-8ba1-1fcd8e51cadd",
    "metadata": {},
    "outputs": [
@@ -18008,7 +18008,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18019,7 +18019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 107,
    "id": "ee4d99fb-1eba-4490-b0fa-077c21f0af59",
    "metadata": {},
    "outputs": [
@@ -18032,7 +18032,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18043,7 +18043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 108,
    "id": "f84437f0-d715-4197-bdf0-6de3652aa819",
    "metadata": {},
    "outputs": [
@@ -18056,7 +18056,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18083,7 +18083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 109,
    "id": "80ff15f7-335e-41a9-be0c-38063c47b3e3",
    "metadata": {},
    "outputs": [
@@ -18093,7 +18093,7 @@
        "(60405, 15)"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18104,7 +18104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 110,
    "id": "79ba8b00-144d-48bb-b410-41e52dc2fbb9",
    "metadata": {},
    "outputs": [
@@ -18114,7 +18114,7 @@
        "np.int64(60405)"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18125,7 +18125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 111,
    "id": "7f733a1b-6029-4775-aa0d-4c8c4052b8ca",
    "metadata": {},
    "outputs": [
@@ -18138,7 +18138,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18157,7 +18157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 112,
    "id": "ca0508db-1d21-4ebd-a74a-e6ed8405c83b",
    "metadata": {},
    "outputs": [
@@ -18175,7 +18175,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18186,7 +18186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 113,
    "id": "71ee3ccf-a3bd-4183-9ea9-d664070d3abe",
    "metadata": {},
    "outputs": [
@@ -18204,7 +18204,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18223,7 +18223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 114,
    "id": "aed2ba0f-c6c9-42f9-93ad-30f4156f409a",
    "metadata": {},
    "outputs": [
@@ -18428,7 +18428,7 @@
        "[750 rows x 8 columns]"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18444,7 +18444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 115,
    "id": "cdbde1b9-7ce9-4371-bc2c-4d6da95191b8",
    "metadata": {},
    "outputs": [
@@ -18458,7 +18458,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18469,7 +18469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 116,
    "id": "85a64702-ab38-4e63-b4de-f0e8fedaee30",
    "metadata": {},
    "outputs": [
@@ -18698,7 +18698,7 @@
        "35927   documentation            test  "
       ]
      },
-     "execution_count": 112,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18718,7 +18718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 117,
    "id": "8e13f5d0-3b8d-471c-9d0b-a85c090c6f93",
    "metadata": {},
    "outputs": [
@@ -18765,7 +18765,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18776,7 +18776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 118,
    "id": "7cf9c312-7922-4608-8d0f-67775a0ecc0a",
    "metadata": {},
    "outputs": [
@@ -18786,7 +18786,7 @@
        "0.00019865905140302955"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18797,7 +18797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 119,
    "id": "55ff4221-2480-4aa2-9553-cb7b3603830f",
    "metadata": {},
    "outputs": [
@@ -18835,50 +18835,50 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>27695</th>\n",
-       "      <td>pandas-113</td>\n",
-       "      <td>C_6_7</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>8705aad961dd227d38ff93a39697547b98109c9d</td>\n",
-       "      <td>pandas/conftest.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>674</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>test</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35887</th>\n",
-       "      <td>pandas-19</td>\n",
-       "      <td>D_4_3</td>\n",
-       "      <td>U3</td>\n",
-       "      <td>c6a1638bcd99df677a8f76f036c0b30027eb243c</td>\n",
-       "      <td>pandas/tests/indexing/multiindex/test_loc.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>298</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>test</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>497</th>\n",
+       "      <th>494</th>\n",
        "      <td>ansible-10</td>\n",
        "      <td>B_4_15</td>\n",
        "      <td>U1</td>\n",
        "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
        "      <td>test/units/modules/system/test_pamd.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>139</td>\n",
+       "      <td>138</td>\n",
        "      <td>documentation</td>\n",
        "      <td>test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>27686</th>\n",
+       "      <th>491</th>\n",
+       "      <td>ansible-10</td>\n",
+       "      <td>B_4_15</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
+       "      <td>test/units/modules/system/test_pamd.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>137</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27692</th>\n",
        "      <td>pandas-113</td>\n",
        "      <td>C_6_7</td>\n",
        "      <td>U2</td>\n",
        "      <td>8705aad961dd227d38ff93a39697547b98109c9d</td>\n",
        "      <td>pandas/conftest.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>671</td>\n",
+       "      <td>673</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>500</th>\n",
+       "      <td>ansible-10</td>\n",
+       "      <td>B_4_15</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
+       "      <td>test/units/modules/system/test_pamd.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>140</td>\n",
        "      <td>documentation</td>\n",
        "      <td>test</td>\n",
        "    </tr>\n",
@@ -18888,25 +18888,25 @@
       ],
       "text/plain": [
        "              bug  bundle user                                       sha  \\\n",
-       "27695  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
-       "35887   pandas-19   D_4_3   U3  c6a1638bcd99df677a8f76f036c0b30027eb243c   \n",
-       "497    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
-       "27686  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
+       "494    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "491    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "27692  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
+       "500    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
        "\n",
-       "                                               file        image  line  \\\n",
-       "27695                            pandas/conftest.py  afterChange   674   \n",
-       "35887  pandas/tests/indexing/multiindex/test_loc.py  afterChange   298   \n",
-       "497          test/units/modules/system/test_pamd.py  afterChange   139   \n",
-       "27686                            pandas/conftest.py  afterChange   671   \n",
+       "                                         file        image  line  \\\n",
+       "494    test/units/modules/system/test_pamd.py  afterChange   138   \n",
+       "491    test/units/modules/system/test_pamd.py  afterChange   137   \n",
+       "27692                      pandas/conftest.py  afterChange   673   \n",
+       "500    test/units/modules/system/test_pamd.py  afterChange   140   \n",
        "\n",
        "      annotation_hapy annotation_auto  \n",
-       "27695   documentation            test  \n",
-       "35887   documentation            test  \n",
-       "497     documentation            test  \n",
-       "27686   documentation            test  "
+       "494     documentation            test  \n",
+       "491     documentation            test  \n",
+       "27692   documentation            test  \n",
+       "500     documentation            test  "
       ]
      },
-     "execution_count": 115,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18939,7 +18939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 120,
    "id": "4ea383bf-ca19-45f3-aecb-544ceca86c48",
    "metadata": {},
    "outputs": [
@@ -19228,7 +19228,7 @@
        "46003        bug(fix)  "
       ]
      },
-     "execution_count": 116,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19248,7 +19248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 121,
    "id": "903cbddf-ce60-44b4-b2ea-77992302bf8f",
    "metadata": {},
    "outputs": [
@@ -19258,7 +19258,7 @@
        "0.0002648787352040394"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19269,7 +19269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 122,
    "id": "f23c439d-d1ea-4f68-a472-252c7d9a9d6c",
    "metadata": {},
    "outputs": [
@@ -19319,38 +19319,14 @@
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>26358</th>\n",
-       "      <td>pandas-105</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>cb5f9d1ff407f5ccef7c717e0c23bbd6ed96cf5f</td>\n",
-       "      <td>pandas/core/generic.py</td>\n",
-       "      <td>beforeChange</td>\n",
-       "      <td>668</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>46003</th>\n",
-       "      <td>pandas-91</td>\n",
-       "      <td>D_3_4</td>\n",
+       "      <th>3793</th>\n",
+       "      <td>black-15</td>\n",
+       "      <td>D_6_1</td>\n",
        "      <td>U3</td>\n",
-       "      <td>cb9a1c7d0319c34a97247973ca96af53ead8033a</td>\n",
-       "      <td>pandas/core/indexes/timedeltas.py</td>\n",
+       "      <td>df2ae3bbe6c45298aabb6c04e85cb353205626f1</td>\n",
+       "      <td>black.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>374</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>45587</th>\n",
-       "      <td>pandas-90</td>\n",
-       "      <td>C_3_10</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>1c3d64bae7c07b5ae1be337e0ebd751385b7ce27</td>\n",
-       "      <td>pandas/io/pickle.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>165</td>\n",
+       "      <td>2567</td>\n",
        "      <td>documentation</td>\n",
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
@@ -19366,34 +19342,58 @@
        "      <td>documentation</td>\n",
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45599</th>\n",
+       "      <td>pandas-90</td>\n",
+       "      <td>C_3_10</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>1c3d64bae7c07b5ae1be337e0ebd751385b7ce27</td>\n",
+       "      <td>pandas/io/pickle.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>169</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7724</th>\n",
+       "      <td>cookiecutter-4</td>\n",
+       "      <td>C_6_7</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>457a1a4e862aab4102b644ff1d2b2e2b5a766b3c</td>\n",
+       "      <td>cookiecutter/exceptions.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>85</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "              bug  bundle user                                       sha  \\\n",
-       "13912    keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
-       "26358  pandas-105   C_5_8   U2  cb5f9d1ff407f5ccef7c717e0c23bbd6ed96cf5f   \n",
-       "46003   pandas-91   D_3_4   U3  cb9a1c7d0319c34a97247973ca96af53ead8033a   \n",
-       "45587   pandas-90  C_3_10   U2  1c3d64bae7c07b5ae1be337e0ebd751385b7ce27   \n",
-       "13909    keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
+       "                  bug  bundle user                                       sha  \\\n",
+       "13912        keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
+       "3793         black-15   D_6_1   U3  df2ae3bbe6c45298aabb6c04e85cb353205626f1   \n",
+       "13909        keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
+       "45599       pandas-90  C_3_10   U2  1c3d64bae7c07b5ae1be337e0ebd751385b7ce27   \n",
+       "7724   cookiecutter-4   C_6_7   U2  457a1a4e862aab4102b644ff1d2b2e2b5a766b3c   \n",
        "\n",
-       "                                    file         image  line annotation_hapy  \\\n",
-       "13912     keras/engine/training_utils.py   afterChange   594   documentation   \n",
-       "26358             pandas/core/generic.py  beforeChange   668   documentation   \n",
-       "46003  pandas/core/indexes/timedeltas.py   afterChange   374   documentation   \n",
-       "45587                pandas/io/pickle.py   afterChange   165   documentation   \n",
-       "13909     keras/engine/training_utils.py   afterChange   593   documentation   \n",
+       "                                 file        image  line annotation_hapy  \\\n",
+       "13912  keras/engine/training_utils.py  afterChange   594   documentation   \n",
+       "3793                         black.py  afterChange  2567   documentation   \n",
+       "13909  keras/engine/training_utils.py  afterChange   593   documentation   \n",
+       "45599             pandas/io/pickle.py  afterChange   169   documentation   \n",
+       "7724       cookiecutter/exceptions.py  afterChange    85   documentation   \n",
        "\n",
        "      annotation_auto  \n",
        "13912        bug(fix)  \n",
-       "26358        bug(fix)  \n",
-       "46003        bug(fix)  \n",
-       "45587        bug(fix)  \n",
-       "13909        bug(fix)  "
+       "3793         bug(fix)  \n",
+       "13909        bug(fix)  \n",
+       "45599        bug(fix)  \n",
+       "7724         bug(fix)  "
       ]
      },
-     "execution_count": 118,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19416,7 +19416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 123,
    "id": "85b04f2f-77ed-40c7-b9a5-091eae5071ec",
    "metadata": {},
    "outputs": [
@@ -19432,7 +19432,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19443,7 +19443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 124,
    "id": "73a487a9-c04f-4802-a81d-72c896d874eb",
    "metadata": {},
    "outputs": [
@@ -19566,7 +19566,7 @@
        "56651             both     False            True  "
       ]
      },
-     "execution_count": 120,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19577,7 +19577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 125,
    "id": "f662ae85-66d7-4b47-a491-1d736fad86e4",
    "metadata": {},
    "outputs": [
@@ -19892,7 +19892,7 @@
        "[87 rows x 15 columns]"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19911,7 +19911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 126,
    "id": "74e45c32-63b1-4f07-a74f-cfd653df1ad0",
    "metadata": {},
    "outputs": [
@@ -19929,7 +19929,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19940,7 +19940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 127,
    "id": "f7acb690-8b6d-411f-9fbd-1b34e231988c",
    "metadata": {},
    "outputs": [
@@ -19956,7 +19956,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19998,7 +19998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 128,
    "id": "a41f6224-fbc4-4b99-b4b3-eda3970819bd",
    "metadata": {},
    "outputs": [
@@ -20015,7 +20015,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20034,7 +20034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 129,
    "id": "ca1273ae-4edd-4666-aefa-671e0d8f79ea",
    "metadata": {},
    "outputs": [
@@ -20292,7 +20292,7 @@
        "56843            True  "
       ]
      },
-     "execution_count": 125,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20312,7 +20312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 130,
    "id": "3c4807c0-7e25-42e5-952a-89265872f6e1",
    "metadata": {},
    "outputs": [
@@ -20529,7 +20529,7 @@
        "[77 rows x 9 columns]"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20544,7 +20544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 131,
    "id": "d2ef0a92-815e-44a5-9ec2-7a7399f8f2fe",
    "metadata": {},
    "outputs": [
@@ -20582,38 +20582,38 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1311</th>\n",
-       "      <td>ansible-17</td>\n",
-       "      <td>D_6_1</td>\n",
+       "      <th>1729</th>\n",
+       "      <td>ansible-4</td>\n",
+       "      <td>D_2_5</td>\n",
        "      <td>U3</td>\n",
-       "      <td>b38cb37728df76e0529243bdce694b18ca0e1163</td>\n",
-       "      <td>changelogs/fragments/mount-facts-octal-escapes...</td>\n",
+       "      <td>18a66e291dad71128a32d662aa808213acefe0e9</td>\n",
+       "      <td>changelogs/fragments/68723-force-static-collec...</td>\n",
        "      <td>afterChange</td>\n",
        "      <td>2</td>\n",
        "      <td>documentation</td>\n",
        "      <td>data</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18680</th>\n",
-       "      <td>keras-43</td>\n",
-       "      <td>B_3_16</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>b17169ca5d6cd1c8aeb237fc2bb0555c9e1b6a02</td>\n",
-       "      <td>docs/mkdocs.yml</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>2</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>data</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>470</th>\n",
-       "      <td>ansible-10</td>\n",
-       "      <td>B_4_15</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
-       "      <td>changelogs/fragments/66398-pamd_fix-attributee...</td>\n",
+       "      <th>905</th>\n",
+       "      <td>ansible-13</td>\n",
+       "      <td>A_3_22</td>\n",
+       "      <td>E3</td>\n",
+       "      <td>694ef5660d45fcb97c9beea5b2750f6eadcf5e93</td>\n",
+       "      <td>changelogs/fragments/collection-install-url.yaml</td>\n",
        "      <td>afterChange</td>\n",
        "      <td>1</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56840</th>\n",
+       "      <td>tornado-3</td>\n",
+       "      <td>A_5_20</td>\n",
+       "      <td>E2</td>\n",
+       "      <td>aa622e724f80e0f7fcee369f75d69d1db13d72f2</td>\n",
+       "      <td>.travis.yml</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>87</td>\n",
        "      <td>documentation</td>\n",
        "      <td>data</td>\n",
        "    </tr>\n",
@@ -20630,26 +20630,26 @@
        "      <td>data</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>903</th>\n",
-       "      <td>ansible-13</td>\n",
-       "      <td>B_5_14</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>694ef5660d45fcb97c9beea5b2750f6eadcf5e93</td>\n",
-       "      <td>changelogs/fragments/collection-install-url.yaml</td>\n",
+       "      <th>715</th>\n",
+       "      <td>ansible-12</td>\n",
+       "      <td>D_5_2</td>\n",
+       "      <td>U3</td>\n",
+       "      <td>2fa8f9cfd80daf32c7d222190edf7cfc7234582a</td>\n",
+       "      <td>changelogs/fragments/65541-fix-utf8-issue-env-...</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>1</td>\n",
+       "      <td>2</td>\n",
        "      <td>documentation</td>\n",
        "      <td>data</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2687</th>\n",
-       "      <td>ansible-8</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>fc7980af9a42676913b4054163570ee438b82e9c</td>\n",
-       "      <td>changelogs/fragments/66604-powershell-unc-path...</td>\n",
+       "      <th>1309</th>\n",
+       "      <td>ansible-17</td>\n",
+       "      <td>B_1_18</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>b38cb37728df76e0529243bdce694b18ca0e1163</td>\n",
+       "      <td>changelogs/fragments/mount-facts-octal-escapes...</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>2</td>\n",
+       "      <td>1</td>\n",
        "      <td>documentation</td>\n",
        "      <td>data</td>\n",
        "    </tr>\n",
@@ -20659,31 +20659,31 @@
       ],
       "text/plain": [
        "              bug  bundle user                                       sha  \\\n",
-       "1311   ansible-17   D_6_1   U3  b38cb37728df76e0529243bdce694b18ca0e1163   \n",
-       "18680    keras-43  B_3_16   U1  b17169ca5d6cd1c8aeb237fc2bb0555c9e1b6a02   \n",
-       "470    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "1729    ansible-4   D_2_5   U3  18a66e291dad71128a32d662aa808213acefe0e9   \n",
+       "905    ansible-13  A_3_22   E3  694ef5660d45fcb97c9beea5b2750f6eadcf5e93   \n",
+       "56840   tornado-3  A_5_20   E2  aa622e724f80e0f7fcee369f75d69d1db13d72f2   \n",
        "468    ansible-10  A_2_23   E2  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
-       "903    ansible-13  B_5_14   U1  694ef5660d45fcb97c9beea5b2750f6eadcf5e93   \n",
-       "2687    ansible-8   C_5_8   U2  fc7980af9a42676913b4054163570ee438b82e9c   \n",
+       "715    ansible-12   D_5_2   U3  2fa8f9cfd80daf32c7d222190edf7cfc7234582a   \n",
+       "1309   ansible-17  B_1_18   U1  b38cb37728df76e0529243bdce694b18ca0e1163   \n",
        "\n",
-       "                                                    file        image  line  \\\n",
-       "1311   changelogs/fragments/mount-facts-octal-escapes...  afterChange     2   \n",
-       "18680                                    docs/mkdocs.yml  afterChange     2   \n",
-       "470    changelogs/fragments/66398-pamd_fix-attributee...  afterChange     1   \n",
-       "468    changelogs/fragments/66398-pamd_fix-attributee...  afterChange     1   \n",
-       "903     changelogs/fragments/collection-install-url.yaml  afterChange     1   \n",
-       "2687   changelogs/fragments/66604-powershell-unc-path...  afterChange     2   \n",
+       "                                                    file         image  line  \\\n",
+       "1729   changelogs/fragments/68723-force-static-collec...   afterChange     2   \n",
+       "905     changelogs/fragments/collection-install-url.yaml   afterChange     1   \n",
+       "56840                                        .travis.yml  beforeChange    87   \n",
+       "468    changelogs/fragments/66398-pamd_fix-attributee...   afterChange     1   \n",
+       "715    changelogs/fragments/65541-fix-utf8-issue-env-...   afterChange     2   \n",
+       "1309   changelogs/fragments/mount-facts-octal-escapes...   afterChange     1   \n",
        "\n",
        "      annotation_hapy annotation_auto  \n",
-       "1311    documentation            data  \n",
-       "18680   documentation            data  \n",
-       "470     documentation            data  \n",
+       "1729    documentation            data  \n",
+       "905     documentation            data  \n",
+       "56840   documentation            data  \n",
        "468     documentation            data  \n",
-       "903     documentation            data  \n",
-       "2687    documentation            data  "
+       "715     documentation            data  \n",
+       "1309    documentation            data  "
       ]
      },
-     "execution_count": 127,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20698,7 +20698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 132,
    "id": "7181a32b-eced-4c99-9146-21ad84c8ea80",
    "metadata": {},
    "outputs": [
@@ -20852,7 +20852,7 @@
        "4                bug(fix)        bug(fix)     False           False  "
       ]
      },
-     "execution_count": 128,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20874,7 +20874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 133,
    "id": "97ea4c1d-e95d-4700-a372-680a1cfe8bdd",
    "metadata": {},
    "outputs": [
@@ -20887,7 +20887,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 129,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20898,7 +20898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 134,
    "id": "62009f45-4767-4690-8cc6-a3c04007741e",
    "metadata": {},
    "outputs": [
@@ -20911,7 +20911,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20938,7 +20938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 135,
    "id": "5fe7d5f7-c22e-4129-8b40-a3cadb16fdb0",
    "metadata": {},
    "outputs": [
@@ -20955,7 +20955,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 131,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20967,7 +20967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 136,
    "id": "a3e28313-ff8d-4253-b42c-541b6c7b46dd",
    "metadata": {},
    "outputs": [
@@ -20977,7 +20977,7 @@
        "['U2', 'U3', 'U1', 'E2', 'E3', 'E1']"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20989,7 +20989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 137,
    "id": "b25ba619-7378-4462-b396-ff4b9041642e",
    "metadata": {},
    "outputs": [
@@ -21206,7 +21206,7 @@
        "[1787 rows x 9 columns]"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21222,7 +21222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 138,
    "id": "466dfed0-d537-4c17-ad1a-fd68840e8bca",
    "metadata": {},
    "outputs": [
@@ -21232,7 +21232,7 @@
        "(14874, 15)"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21243,7 +21243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 139,
    "id": "d2e35c0a-d94d-4cce-ba11-d43f06ae382c",
    "metadata": {},
    "outputs": [
@@ -21256,7 +21256,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21267,7 +21267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 140,
    "id": "06f5e3d0-7016-4d62-a117-2355d1bbb85a",
    "metadata": {},
    "outputs": [
@@ -21295,7 +21295,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21306,7 +21306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 141,
    "id": "7f30c08a-ed1c-4c6a-8c71-d08407dada0e",
    "metadata": {},
    "outputs": [
@@ -21316,7 +21316,7 @@
        "np.float64(0.0700551297566223)"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21328,7 +21328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 142,
    "id": "1edfe252-d79d-4478-b2ce-38566cf9fb36",
    "metadata": {},
    "outputs": [
@@ -21341,7 +21341,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21352,7 +21352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 143,
    "id": "26aa92f4-e848-4fbe-9292-0ebf221c7911",
    "metadata": {},
    "outputs": [
@@ -21362,7 +21362,7 @@
        "np.int64(13832)"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 143,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21374,7 +21374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 144,
    "id": "f6768e5d-900b-4e4c-bf16-0b4883beb032",
    "metadata": {},
    "outputs": [
@@ -21387,7 +21387,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21398,7 +21398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 145,
    "id": "1b8f8ec2-8f86-42c5-9086-177ce7430039",
    "metadata": {},
    "outputs": [
@@ -21420,7 +21420,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 141,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21457,7 +21457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 146,
    "id": "7ce3bc14-5fff-4f16-ad8e-7b16fc14f349",
    "metadata": {},
    "outputs": [
@@ -21474,7 +21474,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 142,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21486,7 +21486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 147,
    "id": "9337b17e-a936-465b-8e6f-f1f83554216d",
    "metadata": {},
    "outputs": [
@@ -21496,7 +21496,7 @@
        "['U2', 'U3', 'U1', 'E2', 'E3', 'E1']"
       ]
      },
-     "execution_count": 143,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21508,7 +21508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 148,
    "id": "ed1b58f4-8f1a-4487-8bb8-55e0bacfcec2",
    "metadata": {},
    "outputs": [],
@@ -21521,7 +21521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 149,
    "id": "b2b5d508-2500-4842-9979-1b997f564a6d",
    "metadata": {},
    "outputs": [],
@@ -21549,7 +21549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 150,
    "id": "6de67c99-447b-4042-b99f-abb3912ddebb",
    "metadata": {},
    "outputs": [
@@ -21559,7 +21559,7 @@
        "(391918, 11)"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21570,7 +21570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 151,
    "id": "8fa64257-63a0-4f80-ba54-16879172d05e",
    "metadata": {},
    "outputs": [
@@ -21580,7 +21580,7 @@
        "(65321.666666666664, 65317.666666666664)"
       ]
      },
-     "execution_count": 147,
+     "execution_count": 151,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21592,7 +21592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 152,
    "id": "1554e983-77f9-4f96-a53d-27193929caad",
    "metadata": {},
    "outputs": [],
@@ -21602,7 +21602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 153,
    "id": "f4c0cb37-ee76-4b39-bfa5-831cdf03931c",
    "metadata": {},
    "outputs": [
@@ -21618,7 +21618,7 @@
        " 'test']"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21630,7 +21630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 154,
    "id": "b1aaf654-20f9-450b-93dc-a959e72d8163",
    "metadata": {},
    "outputs": [
@@ -21648,7 +21648,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21659,7 +21659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 155,
    "id": "6e384092-bfbc-49a7-8129-613bccd681c9",
    "metadata": {},
    "outputs": [
@@ -21900,7 +21900,7 @@
        "[145269 rows x 11 columns]"
       ]
      },
-     "execution_count": 151,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21911,7 +21911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 156,
    "id": "af230d51-4df2-4b32-bcf7-7a3d3bea7b44",
    "metadata": {},
    "outputs": [],
@@ -21933,7 +21933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 157,
    "id": "f2a7b9ab-e071-4cd2-a12c-257b1f33a1ef",
    "metadata": {},
    "outputs": [],
@@ -21950,7 +21950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 158,
    "id": "f0ef57ab-0db8-4008-986a-dad4f6223f46",
    "metadata": {},
    "outputs": [],
@@ -21972,7 +21972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 159,
    "id": "c6d6e631-19a4-4055-a379-8545e858df6c",
    "metadata": {
     "scrolled": true
@@ -36005,7 +36005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 160,
    "id": "2a306642-1b7a-403d-93b2-e83fdf92896e",
    "metadata": {
     "scrolled": true
@@ -36017,7 +36017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 161,
    "id": "021a3e5a-c16f-46f6-a962-3bcf4e0d56f0",
    "metadata": {},
    "outputs": [
@@ -36332,7 +36332,7 @@
        "[145269 rows x 15 columns]"
       ]
      },
-     "execution_count": 157,
+     "execution_count": 161,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36343,7 +36343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 162,
    "id": "726a0fe7-b950-4285-aaa5-fcd8da299ee7",
    "metadata": {},
    "outputs": [
@@ -36356,7 +36356,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 158,
+     "execution_count": 162,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36367,7 +36367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 163,
    "id": "79ff8214-2863-46cb-ae29-0a66bf198366",
    "metadata": {},
    "outputs": [
@@ -36380,7 +36380,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 159,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36391,7 +36391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 164,
    "id": "81952f48-5f18-4f60-ab28-fc328324d2c6",
    "metadata": {},
    "outputs": [
@@ -36409,7 +36409,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 160,
+     "execution_count": 164,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36420,7 +36420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 165,
    "id": "9e317562-5432-4561-b639-a083cfa616c8",
    "metadata": {},
    "outputs": [
@@ -36430,7 +36430,7 @@
        "np.float64(0.9765400739318093)"
       ]
      },
-     "execution_count": 161,
+     "execution_count": 165,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36441,7 +36441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 166,
    "id": "e8152f2f-a5d7-406c-af31-4de633abc89c",
    "metadata": {},
    "outputs": [
@@ -36454,7 +36454,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 162,
+     "execution_count": 166,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36465,7 +36465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 167,
    "id": "460868a3-fc3d-4ce2-8d30-c7b992c96446",
    "metadata": {},
    "outputs": [
@@ -36478,7 +36478,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 163,
+     "execution_count": 167,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36489,7 +36489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": 168,
    "id": "8018e39f-ef05-4308-b546-79317a9683a0",
    "metadata": {},
    "outputs": [
@@ -36497,7 +36497,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 jnareb jnareb 19M Nov 30 20:13 consensus.csv\n"
+      "-rw-r--r-- 1 jnareb jnareb 19M Dec  5 09:35 consensus.csv\n"
      ]
     }
    ],
@@ -36516,7 +36516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": 169,
    "id": "0fe9ec45-c2f4-42cf-bbe3-67d09c80bea7",
    "metadata": {},
    "outputs": [
@@ -36831,7 +36831,7 @@
        "[20221 rows x 15 columns]"
       ]
      },
-     "execution_count": 165,
+     "execution_count": 169,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36851,7 +36851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 170,
    "id": "6dcd1567-2efc-4686-bcde-acfcacfb8b4f",
    "metadata": {},
    "outputs": [
@@ -36861,7 +36861,7 @@
        "(145269, 15)"
       ]
      },
-     "execution_count": 166,
+     "execution_count": 170,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36872,7 +36872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 171,
    "id": "c37dfd29-090f-4331-85be-0099c1b55235",
    "metadata": {},
    "outputs": [
@@ -36882,7 +36882,7 @@
        "(20221, 15)"
       ]
      },
-     "execution_count": 167,
+     "execution_count": 171,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36893,7 +36893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 172,
    "id": "38336cfd-a192-45ac-b45b-fc47bded13a3",
    "metadata": {},
    "outputs": [
@@ -36903,7 +36903,7 @@
        "(19762, 15)"
       ]
      },
-     "execution_count": 168,
+     "execution_count": 172,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36915,7 +36915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 173,
    "id": "2767f18f-0d43-4f62-934d-016310ce47ab",
    "metadata": {},
    "outputs": [
@@ -36928,7 +36928,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 169,
+     "execution_count": 173,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36947,7 +36947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 174,
    "id": "498e692d-4659-40bc-86f3-02087d504183",
    "metadata": {},
    "outputs": [
@@ -37071,7 +37071,7 @@
        "4    programming   afterChange   139       bug(fix)  "
       ]
      },
-     "execution_count": 170,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37083,7 +37083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 175,
    "id": "75bc16b3-3079-42de-bf35-b2d8452a78ee",
    "metadata": {},
    "outputs": [
@@ -37188,7 +37188,7 @@
        "4  httpie/downloads.py   afterChange   139       bug(fix)  "
       ]
      },
-     "execution_count": 171,
+     "execution_count": 175,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37200,7 +37200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 176,
    "id": "9ad7ca7e-92b4-4531-81b1-99d4640c0a24",
    "metadata": {},
    "outputs": [
@@ -37311,7 +37311,7 @@
        "4   135            3             2  bug(fix) + refactoring  "
       ]
      },
-     "execution_count": 172,
+     "execution_count": 176,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37323,7 +37323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 177,
    "id": "430cd66d-3664-4a89-93a0-2b225c43a2c6",
    "metadata": {},
    "outputs": [
@@ -37428,7 +37428,7 @@
        "4  httpie/downloads.py   afterChange   139       bug(fix)  "
       ]
      },
-     "execution_count": 173,
+     "execution_count": 177,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37448,7 +37448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 178,
    "id": "6555b32a-f4e8-4cc5-9466-e9c0b69ba727",
    "metadata": {},
    "outputs": [
@@ -37584,7 +37584,7 @@
        "4  56f22f8ffe1c6b2be4d2cf3ad1987fdb66113da2   bug(fix)             both  "
       ]
      },
-     "execution_count": 174,
+     "execution_count": 178,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37608,7 +37608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 179,
    "id": "aa78dd19-2dcb-4da3-8d9e-717d83f2ff80",
    "metadata": {},
    "outputs": [
@@ -37744,7 +37744,7 @@
        "4  56f22f8ffe1c6b2be4d2cf3ad1987fdb66113da2   bug(fix)             both  "
       ]
      },
-     "execution_count": 175,
+     "execution_count": 179,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37768,7 +37768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 180,
    "id": "0de898de-acac-483b-a29c-a469b0c62c48",
    "metadata": {},
    "outputs": [
@@ -37880,7 +37880,7 @@
        "4   afterChange    18   bug(fix)  "
       ]
      },
-     "execution_count": 176,
+     "execution_count": 180,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -37892,7 +37892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 181,
    "id": "47cf36df-d9de-4117-a160-96d4fc822965",
    "metadata": {},
    "outputs": [
@@ -38028,7 +38028,7 @@
        "4  56f22f8ffe1c6b2be4d2cf3ad1987fdb66113da2   bug(fix)             both  "
       ]
      },
-     "execution_count": 177,
+     "execution_count": 181,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38044,7 +38044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 182,
    "id": "b1344b90-502d-4811-8175-3fff56fa5a00",
    "metadata": {},
    "outputs": [
@@ -38058,7 +38058,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 182,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38077,7 +38077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 183,
    "id": "62db9167-76d0-421b-b3cc-4b83f44df1b4",
    "metadata": {},
    "outputs": [
@@ -38220,7 +38220,7 @@
        "4           2.0             both  "
       ]
      },
-     "execution_count": 179,
+     "execution_count": 183,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38237,7 +38237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 184,
    "id": "469b5f86-69ed-4782-962e-1797ca9ff578",
    "metadata": {},
    "outputs": [
@@ -38250,7 +38250,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 184,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38263,7 +38263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 185,
    "id": "eb028486-869d-478c-9ce2-1a3d0a033966",
    "metadata": {},
    "outputs": [
@@ -38276,7 +38276,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 185,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38289,7 +38289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 186,
    "id": "0fbb2a52-d026-4398-b0cc-016086dece24",
    "metadata": {},
    "outputs": [
@@ -38309,7 +38309,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 182,
+     "execution_count": 186,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38324,7 +38324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 187,
    "id": "1008dfd1-e7a2-4edf-a097-11ccdafe2586",
    "metadata": {},
    "outputs": [
@@ -38334,7 +38334,7 @@
        "20432"
       ]
      },
-     "execution_count": 183,
+     "execution_count": 187,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38345,7 +38345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 188,
    "id": "bba01c6d-19bf-4570-b32e-0e68f1bc0041",
    "metadata": {},
    "outputs": [
@@ -38358,7 +38358,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 184,
+     "execution_count": 188,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38369,7 +38369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 189,
    "id": "2d9a08b4-959c-4091-b83d-8512a8852ed0",
    "metadata": {},
    "outputs": [
@@ -38382,7 +38382,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 185,
+     "execution_count": 189,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38393,7 +38393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 190,
    "id": "774655b0-03dc-4eea-80dc-654a28e166c5",
    "metadata": {},
    "outputs": [
@@ -38406,7 +38406,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 186,
+     "execution_count": 190,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38417,7 +38417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 191,
    "id": "b12b464c-d264-42af-b4e9-9683b206d956",
    "metadata": {},
    "outputs": [
@@ -38440,7 +38440,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 187,
+     "execution_count": 191,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38451,7 +38451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 192,
    "id": "549c9933-e852-4b86-935e-7055aef89fa8",
    "metadata": {},
    "outputs": [
@@ -38474,7 +38474,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 188,
+     "execution_count": 192,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38485,7 +38485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 193,
    "id": "fae43b1f-fcc6-4413-8e40-1f89a45e270d",
    "metadata": {},
    "outputs": [
@@ -38506,7 +38506,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 189,
+     "execution_count": 193,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38517,7 +38517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 194,
    "id": "92ca6830-2117-402a-9074-123f07e0426e",
    "metadata": {},
    "outputs": [
@@ -38538,7 +38538,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 190,
+     "execution_count": 194,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38551,7 +38551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 195,
    "id": "5bcd463f-0088-4f19-989c-b54daa48d0a5",
    "metadata": {},
    "outputs": [
@@ -38572,7 +38572,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 191,
+     "execution_count": 195,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38589,7 +38589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 196,
    "id": "85fd20cb-d143-472c-95be-02f1e5ee68ee",
    "metadata": {},
    "outputs": [
@@ -38868,7 +38868,7 @@
        "[603 rows x 12 columns]"
       ]
      },
-     "execution_count": 192,
+     "execution_count": 196,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -38884,7 +38884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 197,
    "id": "0197eae2-af7f-4b7f-a8d4-2a39d488f35e",
    "metadata": {},
    "outputs": [
@@ -38922,50 +38922,50 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4954</th>\n",
-       "      <td>bugs-in-py_keras-15</td>\n",
-       "      <td>f60313e29657b2afb6a02f28dba5936bc0dd09e6</td>\n",
-       "      <td>keras/callbacks.py</td>\n",
+       "      <th>3682</th>\n",
+       "      <td>bugs-in-py_fastapi-2</td>\n",
+       "      <td>02441ff0313d5b471b662293244c53e712f1243f</td>\n",
+       "      <td>fastapi/routing.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>1143</td>\n",
+       "      <td>504</td>\n",
        "      <td>bug(fix) + refactoring</td>\n",
        "      <td>bug(fix)</td>\n",
        "      <td>2.0</td>\n",
        "      <td>3.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6522</th>\n",
-       "      <td>bugs-in-py_keras-6</td>\n",
-       "      <td>4b54657ab4806b0aaef8f8eeb973edb83c3d3483</td>\n",
-       "      <td>tests/test_loss_masking.py</td>\n",
+       "      <th>1793</th>\n",
+       "      <td>bugs-in-py_black-22</td>\n",
+       "      <td>c55d08d0b96c8de8bd867ca315e380d9e9d2d7ec</td>\n",
+       "      <td>black.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>15</td>\n",
+       "      <td>13</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17983</th>\n",
+       "      <td>bugs-in-py_spacy-8</td>\n",
+       "      <td>5efae495f18f37316bd641a05ca26e62cb78e242</td>\n",
+       "      <td>spacy/matcher/matcher.pyx</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>139</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2759</th>\n",
+       "      <td>bugs-in-py_fastapi-1</td>\n",
+       "      <td>3397d4d69a9c2d64c1219fcbf291ea5697a4abb8</td>\n",
+       "      <td>fastapi/routing.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>54</td>\n",
        "      <td>refactoring</td>\n",
-       "      <td>test</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>3.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18468</th>\n",
-       "      <td>bugs-in-py_thefuck-25</td>\n",
-       "      <td>298c04f89c081dc16c8653aa017ca85dd14bfad6</td>\n",
-       "      <td>tests/rules/test_mkdir_p.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>12</td>\n",
-       "      <td>test + refactoring</td>\n",
-       "      <td>test</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>3.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18187</th>\n",
-       "      <td>bugs-in-py_thefuck-15</td>\n",
-       "      <td>41707b80c61acadb7c87b0efcbf10f4186dc5937</td>\n",
-       "      <td>tests/rules/test_git_add.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>26</td>\n",
-       "      <td>test + refactoring</td>\n",
-       "      <td>test</td>\n",
+       "      <td>bug(fix)</td>\n",
        "      <td>2.0</td>\n",
        "      <td>3.0</td>\n",
        "    </tr>\n",
@@ -38974,26 +38974,26 @@
        "</div>"
       ],
       "text/plain": [
-       "                          id                                       sha  \\\n",
-       "4954     bugs-in-py_keras-15  f60313e29657b2afb6a02f28dba5936bc0dd09e6   \n",
-       "6522      bugs-in-py_keras-6  4b54657ab4806b0aaef8f8eeb973edb83c3d3483   \n",
-       "18468  bugs-in-py_thefuck-25  298c04f89c081dc16c8653aa017ca85dd14bfad6   \n",
-       "18187  bugs-in-py_thefuck-15  41707b80c61acadb7c87b0efcbf10f4186dc5937   \n",
+       "                         id                                       sha  \\\n",
+       "3682   bugs-in-py_fastapi-2  02441ff0313d5b471b662293244c53e712f1243f   \n",
+       "1793    bugs-in-py_black-22  c55d08d0b96c8de8bd867ca315e380d9e9d2d7ec   \n",
+       "17983    bugs-in-py_spacy-8  5efae495f18f37316bd641a05ca26e62cb78e242   \n",
+       "2759   bugs-in-py_fastapi-1  3397d4d69a9c2d64c1219fcbf291ea5697a4abb8   \n",
        "\n",
-       "                              file        image  line               consensus  \\\n",
-       "4954            keras/callbacks.py  afterChange  1143  bug(fix) + refactoring   \n",
-       "6522    tests/test_loss_masking.py  afterChange    15             refactoring   \n",
-       "18468  tests/rules/test_mkdir_p.py  afterChange    12      test + refactoring   \n",
-       "18187  tests/rules/test_git_add.py  afterChange    26      test + refactoring   \n",
+       "                            file        image  line               consensus  \\\n",
+       "3682          fastapi/routing.py  afterChange   504  bug(fix) + refactoring   \n",
+       "1793                    black.py  afterChange    13  bug(fix) + refactoring   \n",
+       "17983  spacy/matcher/matcher.pyx  afterChange   139  bug(fix) + refactoring   \n",
+       "2759          fastapi/routing.py  afterChange    54             refactoring   \n",
        "\n",
        "      annotation  common_count  n_reviewers  \n",
-       "4954    bug(fix)           2.0          3.0  \n",
-       "6522        test           2.0          3.0  \n",
-       "18468       test           2.0          3.0  \n",
-       "18187       test           2.0          3.0  "
+       "3682    bug(fix)           2.0          3.0  \n",
+       "1793    bug(fix)           2.0          3.0  \n",
+       "17983   bug(fix)           2.0          3.0  \n",
+       "2759    bug(fix)           2.0          3.0  "
       ]
      },
-     "execution_count": 193,
+     "execution_count": 197,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39053,7 +39053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": 198,
    "id": "c7350678-e112-4f62-9368-fc8ecec46f17",
    "metadata": {},
    "outputs": [
@@ -39074,7 +39074,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 194,
+     "execution_count": 198,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39087,7 +39087,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 199,
    "id": "b14fbafa-c307-442b-866c-3ed3e8d9eb60",
    "metadata": {},
    "outputs": [
@@ -39108,7 +39108,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 195,
+     "execution_count": 199,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39121,7 +39121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 200,
    "id": "df8946ef-5d82-4f04-997e-b9525459e3f8",
    "metadata": {},
    "outputs": [
@@ -39142,7 +39142,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 196,
+     "execution_count": 200,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39173,7 +39173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 201,
    "id": "78ac3277-d2d8-4fb2-89a6-382ca7b1831a",
    "metadata": {},
    "outputs": [
@@ -39214,46 +39214,46 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>10868</th>\n",
+       "      <th>15325</th>\n",
        "      <td>bugs-in-py</td>\n",
-       "      <td>bugs-in-py_pandas-142</td>\n",
-       "      <td>pandas/tests/series/test_timeseries.py</td>\n",
+       "      <td>bugs-in-py_pandas-9</td>\n",
+       "      <td>pandas/tests/indexes/categorical/test_indexing.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>288</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>test</td>\n",
+       "      <td>ebb727e5cd8865a7f5d6cfb4b22d3278b6bf5e6b</td>\n",
+       "      <td>test</td>\n",
+       "      <td>both</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4635</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_keras-1</td>\n",
+       "      <td>tests/keras/backend/backend_test.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>606</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>test</td>\n",
+       "      <td>8e23a3ec47a2ccbf6cdd222a80886c6b9f17264f</td>\n",
+       "      <td>test</td>\n",
+       "      <td>both</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19566</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_tqdm-3</td>\n",
+       "      <td>tqdm/tests/tests_tqdm.py</td>\n",
        "      <td>beforeChange</td>\n",
-       "      <td>364</td>\n",
+       "      <td>1722</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>test</td>\n",
-       "      <td>65815e6f33e25991e3d40a53c581ffb3c7daf70f</td>\n",
-       "      <td>test</td>\n",
-       "      <td>both</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19797</th>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>bugs-in-py_youtube-dl-14</td>\n",
-       "      <td>youtube_dl/extractor/youtube.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>1667</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>84213ea8d41d5fe1608333a16ac578dccdf9a915</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>both</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18047</th>\n",
-       "      <td>bugs-in-py</td>\n",
-       "      <td>bugs-in-py_thefuck-1</td>\n",
-       "      <td>tests/rules/test_pip_unknown_command.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>20</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>test</td>\n",
-       "      <td>444908ce1c17767ef4aaf9e0b4950497914f7f63</td>\n",
+       "      <td>73962a47026dd980ac0758820efc9c41cbf938e0</td>\n",
        "      <td>test</td>\n",
        "      <td>both</td>\n",
        "      <td>False</td>\n",
@@ -39263,33 +39263,33 @@
        "</div>"
       ],
       "text/plain": [
-       "               ds                        id  \\\n",
-       "10868  bugs-in-py     bugs-in-py_pandas-142   \n",
-       "19797  bugs-in-py  bugs-in-py_youtube-dl-14   \n",
-       "18047  bugs-in-py      bugs-in-py_thefuck-1   \n",
+       "               ds                   id  \\\n",
+       "15325  bugs-in-py  bugs-in-py_pandas-9   \n",
+       "4635   bugs-in-py   bugs-in-py_keras-1   \n",
+       "19566  bugs-in-py    bugs-in-py_tqdm-3   \n",
        "\n",
-       "                                          file         image  line  \\\n",
-       "10868   pandas/tests/series/test_timeseries.py  beforeChange   364   \n",
-       "19797          youtube_dl/extractor/youtube.py   afterChange  1667   \n",
-       "18047  tests/rules/test_pip_unknown_command.py   afterChange    20   \n",
+       "                                                    file         image  line  \\\n",
+       "15325  pandas/tests/indexes/categorical/test_indexing.py   afterChange   288   \n",
+       "4635                 tests/keras/backend/backend_test.py   afterChange   606   \n",
+       "19566                           tqdm/tests/tests_tqdm.py  beforeChange  1722   \n",
        "\n",
        "       n_reviewers  common_count consensus  \\\n",
-       "10868          3.0           2.0      test   \n",
-       "19797          3.0           3.0  bug(fix)   \n",
-       "18047          3.0           2.0      test   \n",
+       "15325          3.0           3.0      test   \n",
+       "4635           3.0           3.0      test   \n",
+       "19566          3.0           3.0      test   \n",
        "\n",
        "                                            sha annotation indicator_column  \\\n",
-       "10868  65815e6f33e25991e3d40a53c581ffb3c7daf70f       test             both   \n",
-       "19797  84213ea8d41d5fe1608333a16ac578dccdf9a915   bug(fix)             both   \n",
-       "18047  444908ce1c17767ef4aaf9e0b4950497914f7f63       test             both   \n",
+       "15325  ebb727e5cd8865a7f5d6cfb4b22d3278b6bf5e6b       test             both   \n",
+       "4635   8e23a3ec47a2ccbf6cdd222a80886c6b9f17264f       test             both   \n",
+       "19566  73962a47026dd980ac0758820efc9c41cbf938e0       test             both   \n",
        "\n",
        "       annotation_neq  \n",
-       "10868           False  \n",
-       "19797           False  \n",
-       "18047           False  "
+       "15325           False  \n",
+       "4635            False  \n",
+       "19566           False  "
       ]
      },
-     "execution_count": 197,
+     "execution_count": 201,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39312,7 +39312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 202,
    "id": "669852b9-b639-4ba4-98c0-2985057272d4",
    "metadata": {},
    "outputs": [
@@ -39328,7 +39328,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 198,
+     "execution_count": 202,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39344,7 +39344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 203,
    "id": "6d8fe806-e8e7-404d-8fad-039a3b7f45b1",
    "metadata": {},
    "outputs": [
@@ -39360,7 +39360,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 199,
+     "execution_count": 203,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39376,7 +39376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 204,
    "id": "a148d43a-15c2-4a14-9f7f-bcd07d965375",
    "metadata": {},
    "outputs": [
@@ -39386,7 +39386,7 @@
        "np.float64(0.005459650582362729)"
       ]
      },
-     "execution_count": 200,
+     "execution_count": 204,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39418,7 +39418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 205,
    "id": "a9ae406b-c7a8-4b2c-9f3d-e873a4c555da",
    "metadata": {},
    "outputs": [
@@ -39684,7 +39684,7 @@
        "[530 rows x 12 columns]"
       ]
      },
-     "execution_count": 201,
+     "execution_count": 205,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39703,7 +39703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 206,
    "id": "e49fa293-615f-4747-8e68-94595ff05d60",
    "metadata": {},
    "outputs": [
@@ -39969,7 +39969,7 @@
        "[670 rows x 12 columns]"
       ]
      },
-     "execution_count": 202,
+     "execution_count": 206,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39988,7 +39988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 207,
    "id": "dbe18e51-91f3-4082-8a2a-8336cf9caad9",
    "metadata": {},
    "outputs": [
@@ -39998,7 +39998,7 @@
        "np.int64(670)"
       ]
      },
-     "execution_count": 203,
+     "execution_count": 207,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -40009,7 +40009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": 208,
    "id": "21ce1928-9e76-4659-9b98-25029b32180e",
    "metadata": {},
    "outputs": [
@@ -40019,13 +40019,704 @@
        "np.int64(530)"
       ]
      },
-     "execution_count": 204,
+     "execution_count": 208,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "merge_sel_consensus['annotation'].isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 209,
+   "id": "4817d6c3-4954-4116-a324-3ee5027cec40",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds</th>\n",
+       "      <th>id</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>common_count</th>\n",
+       "      <th>consensus</th>\n",
+       "      <th>sha</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>indicator_column</th>\n",
+       "      <th>annotation_neq</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2335</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_black-6</td>\n",
+       "      <td>blib2to3/pgen2/driver.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>122</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>f8617f975d56e81cfb4070ce65584f7b29a77e7a</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>right_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19433</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_tornado-7</td>\n",
+       "      <td>tornado/test/ioloop_test.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>630</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>a3b44cd701e0e82693363701bc0346b0125d2362</td>\n",
+       "      <td>test</td>\n",
+       "      <td>right_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18673</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_thefuck-6</td>\n",
+       "      <td>tests/rules/test_git_branch_exists.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>7</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>7c858fadb3458be829d3d43666ccb46c3ed5b8a0</td>\n",
+       "      <td>test</td>\n",
+       "      <td>right_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               ds                    id  \\\n",
+       "2335   bugs-in-py    bugs-in-py_black-6   \n",
+       "19433  bugs-in-py  bugs-in-py_tornado-7   \n",
+       "18673  bugs-in-py  bugs-in-py_thefuck-6   \n",
+       "\n",
+       "                                        file        image  line  n_reviewers  \\\n",
+       "2335                blib2to3/pgen2/driver.py  afterChange   122          NaN   \n",
+       "19433            tornado/test/ioloop_test.py  afterChange   630          NaN   \n",
+       "18673  tests/rules/test_git_branch_exists.py  afterChange     7          NaN   \n",
+       "\n",
+       "       common_count consensus                                       sha  \\\n",
+       "2335            NaN       NaN  f8617f975d56e81cfb4070ce65584f7b29a77e7a   \n",
+       "19433           NaN       NaN  a3b44cd701e0e82693363701bc0346b0125d2362   \n",
+       "18673           NaN       NaN  7c858fadb3458be829d3d43666ccb46c3ed5b8a0   \n",
+       "\n",
+       "      annotation indicator_column  annotation_neq  \n",
+       "2335    bug(fix)       right_only            True  \n",
+       "19433       test       right_only            True  \n",
+       "18673       test       right_only            True  "
+      ]
+     },
+     "execution_count": 209,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hapy_bip_merge_sel_consensus[hapy_bip_merge_sel_consensus['consensus'].isna()].sample(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "e050a93f-799d-49f5-9d7f-a8da09ed71c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['ds', 'id', 'file', 'image', 'line', 'n_reviewers', 'common_count',\n",
+       "       'consensus'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 210,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G_bip_consensus_sel_2.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "cf8e735e-9b2d-4e1b-b85a-f905ee8fc882",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds</th>\n",
+       "      <th>id</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>common_count</th>\n",
+       "      <th>consensus</th>\n",
+       "      <th>sha</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>indicator_column</th>\n",
+       "      <th>annotation_neq</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4017</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>80</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17696</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_spacy-3</td>\n",
+       "      <td>.github/contributors/elben10</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>55</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17718</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_spacy-3</td>\n",
+       "      <td>.github/contributors/elben10</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>77</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               ds                    id  \\\n",
+       "4017   bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "17696  bugs-in-py    bugs-in-py_spacy-3   \n",
+       "17718  bugs-in-py    bugs-in-py_spacy-3   \n",
+       "\n",
+       "                                             file        image  line  \\\n",
+       "4017   tests/test_param_in_path_and_dependency.py  afterChange    80   \n",
+       "17696                .github/contributors/elben10  afterChange    55   \n",
+       "17718                .github/contributors/elben10  afterChange    77   \n",
+       "\n",
+       "       n_reviewers  common_count      consensus  sha annotation  \\\n",
+       "4017           3.0           3.0           test  NaN        NaN   \n",
+       "17696          3.0           3.0  documentation  NaN        NaN   \n",
+       "17718          3.0           3.0  documentation  NaN        NaN   \n",
+       "\n",
+       "      indicator_column  annotation_neq  \n",
+       "4017         left_only            True  \n",
+       "17696        left_only            True  \n",
+       "17718        left_only            True  "
+      ]
+     },
+     "execution_count": 211,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hapy_bip_merge_sel_consensus[hapy_bip_merge_sel_consensus['annotation'].isna()].sample(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "761c8754-2723-4b7a-854a-cb5beaf3ca4f",
+   "metadata": {},
+   "source": [
+    "Example:\n",
+    "- id: `bugs-in-py_fastapi-4`\n",
+    "- file: `tests/test_param_in_path_and_dependency.py`\n",
+    "- image: `afterChange`\n",
+    "- line: 80"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 220,
+   "id": "4322b2fe-0efe-421a-9aef-95b26b0c9344",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'commits': ['7f6804c4953a18386809f11faf4d86898570debc',\n",
+       "  '7129d474206761a6156925db78eee4b62a0e3944',\n",
+       "  '90434ff4ea4477941444f1e83313beb414838535',\n",
+       "  '457a1a4e862aab4102b644ff1d2b2e2b5a766b3c'],\n",
+       " 'bugs': ['cookiecutter-1',\n",
+       "  'cookiecutter-3',\n",
+       "  'cookiecutter-2',\n",
+       "  'cookiecutter-4']}"
+      ]
+     },
+     "execution_count": 220,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# let's emind ourself of the structure of `repo_commits` dict\n",
+    "repo_commits['cookiecutter']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "id": "3b4bebc9-7ec1-428f-a2ea-76046817fb86",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[2]"
+      ]
+     },
+     "execution_count": 215,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[i for i, name in enumerate(repo_commits['fastapi']['bugs']) if name == 'fastapi-4']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 216,
+   "id": "dd10a0fd-68d2-4953-b6ea-bb968433b413",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'fastapi-4'"
+      ]
+     },
+     "execution_count": 216,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "repo_commits['fastapi']['bugs'][2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 217,
+   "id": "d4e0c7b1-fa05-47b1-9c2b-a14216c4a4cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3'"
+      ]
+     },
+     "execution_count": 217,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "repo_commits['fastapi']['commits'][2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 218,
+   "id": "aaf23109-387b-4e2f-88f5-fcc922193359",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['ds', 'id', 'sha', 'file', 'image', 'line', 'annotation'], dtype='object')"
+      ]
+     },
+     "execution_count": 218,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from_repos_df_sel_2.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "id": "833f46e1-ec6c-4d38-a0b5-ac04b93aaad7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds</th>\n",
+       "      <th>id</th>\n",
+       "      <th>sha</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>16665</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>64</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16666</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>65</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16667</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>85</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16668</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>86</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16669</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>87</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16670</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>88</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16671</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>91</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16672</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_fastapi-4</td>\n",
+       "      <td>74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3</td>\n",
+       "      <td>tests/test_param_in_path_and_dependency.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>92</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               ds                    id  \\\n",
+       "16665  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16666  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16667  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16668  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16669  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16670  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16671  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "16672  bugs-in-py  bugs-in-py_fastapi-4   \n",
+       "\n",
+       "                                            sha  \\\n",
+       "16665  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16666  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16667  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16668  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16669  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16670  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16671  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "16672  74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3   \n",
+       "\n",
+       "                                             file        image  line  \\\n",
+       "16665  tests/test_param_in_path_and_dependency.py  afterChange    64   \n",
+       "16666  tests/test_param_in_path_and_dependency.py  afterChange    65   \n",
+       "16667  tests/test_param_in_path_and_dependency.py  afterChange    85   \n",
+       "16668  tests/test_param_in_path_and_dependency.py  afterChange    86   \n",
+       "16669  tests/test_param_in_path_and_dependency.py  afterChange    87   \n",
+       "16670  tests/test_param_in_path_and_dependency.py  afterChange    88   \n",
+       "16671  tests/test_param_in_path_and_dependency.py  afterChange    91   \n",
+       "16672  tests/test_param_in_path_and_dependency.py  afterChange    92   \n",
+       "\n",
+       "      annotation  \n",
+       "16665       test  \n",
+       "16666       test  \n",
+       "16667       test  \n",
+       "16668       test  \n",
+       "16669       test  \n",
+       "16670       test  \n",
+       "16671       test  \n",
+       "16672       test  "
+      ]
+     },
+     "execution_count": 222,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from_repos_df_sel_2[\n",
+    "    (from_repos_df_sel_2['sha'] == '74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3') &\n",
+    "    (from_repos_df_sel_2['file'] == 'tests/test_param_in_path_and_dependency.py')\n",
+    "].tail(8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 225,
+   "id": "90f4aba1-d577-441b-801f-c88b603a242b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 225,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lines = from_repos_df_sel_2[\n",
+    "    (from_repos_df_sel_2['sha'] == '74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3') &\n",
+    "    (from_repos_df_sel_2['file'] == 'tests/test_param_in_path_and_dependency.py')\n",
+    "]['line'].to_list()\n",
+    "80 in lines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2854ebfd-689c-4e5f-8a61-449bc42768a9",
+   "metadata": {},
+   "source": [
+    "Let's examine the diff itself\n",
+    "```console\n",
+    "przybysz:/mnt/data/python_bug_localization_data/repositories/fastapi$ git show 74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3\n",
+    "[...]\n",
+    "diff --git a/tests/test_param_in_path_and_dependency.py b/tests/test_param_in_path_and_dependency.py\n",
+    "new file mode 100644\n",
+    "index 00000000..55b667ee\n",
+    "--- /dev/null\n",
+    "+++ b/tests/test_param_in_path_and_dependency.py\n",
+    "@@ -0,0 +1,93 @@\n",
+    "+from fastapi import Depends, FastAPI\n",
+    "+from starlette.testclient import TestClient\n",
+    "+\n",
+    "+app = FastAPI()\n",
+    "+\n",
+    "+\n",
+    "+async def user_exists(user_id: int):\n",
+    "+    return True\n",
+    "+\n",
+    "+\n",
+    "+@app.get(\"/users/{user_id}\", dependencies=[Depends(user_exists)])\n",
+    "[...]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd939c00-5ac4-4ed7-8297-f3f6459a3782",
+   "metadata": {},
+   "source": [
+    "Let's examine the annotations from `diff-annotate from-repo ...`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca050a46-c971-47a8-91e2-eb2a5e1bd9a0",
+   "metadata": {},
+   "source": [
+    "```console\n",
+    "$ jq '.changes[\"tests/test_param_in_path_and_dependency.py\"][\"+\"]' 74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3.v2.json | grep '\"file_line_no\"'\n",
+    "    \"file_line_no\": 1,\n",
+    "    \"file_line_no\": 7,\n",
+    "    \"file_line_no\": 8,\n",
+    "[...]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea0099dc-f2d9-4d2c-ac7f-ae4d1e6d3e87",
+   "metadata": {},
+   "source": [
+    "It looks like there are some lines missing from parse..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d492130e-eaeb-44fb-b279-336134359c4b",
+   "metadata": {},
+   "source": [
+    "Let's also examine the annotations from `diff-annotate dataset ...`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffce197a-391b-4ed2-acc7-ef4d72706376",
+   "metadata": {},
+   "source": [
+    "```console\n",
+    "$ jq '.changes[\"tests/test_param_in_path_and_dependency.py\"][\"+\"]' \\\n",
+    "    HaPy-Bug/bugsinpy-dataset/fastapi-4/annotation/74c4d1c1dbe6bfdb05d6e4fc767ffe062398f0a3.v2.json | \n",
+    "    grep '\"file_line_no\"'\n",
+    "    \"file_line_no\": 1,\n",
+    "    \"file_line_no\": 2,\n",
+    "    \"file_line_no\": 3,\n",
+    "    \"file_line_no\": 4,\n",
+    "    \"file_line_no\": 5,\n",
+    "    \"file_line_no\": 6,\n",
+    "    \"file_line_no\": 7,\n",
+    "    \"file_line_no\": 8,\n",
+    "    \"file_line_no\": 9,\n",
+    "    \"file_line_no\": 10,\n",
+    "[...]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd91bc2-e3f8-4d6a-906f-a3f59f590235",
+   "metadata": {},
+   "source": [
+    "There are no problems here. So the problem is with the code that tries to match changed lines with result of lexing whole file with Pygments..."
    ]
   },
   {

--- a/notebooks/experiments/02-compare_annotations_Herbold.ipynb
+++ b/notebooks/experiments/02-compare_annotations_Herbold.ipynb
@@ -2993,11 +2993,96 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "28d859b9-4401-424a-9958-fbc725fff736",
+   "cell_type": "code",
+   "execution_count": 158,
+   "id": "bb87be0e-7172-4498-982b-b1a4b2ab8907",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ant-ivy                        has 548 commits\n",
+      "commons-math                   has 391 commits\n",
+      "opennlp                        has 150 commits\n",
+      "archiva                        has   5 commits\n",
+      "commons-bcel                   has  52 commits\n",
+      "commons-beanutils              has  61 commits\n",
+      "commons-codec                  has  58 commits\n",
+      "commons-collections            has  92 commits\n",
+      "commons-compress               has 204 commits\n",
+      "commons-configuration          has 253 commits\n",
+      "commons-dbcp                   has  89 commits\n",
+      "commons-digester               has  26 commits\n",
+      "commons-io                     has 116 commits\n",
+      "commons-jcs                    has  73 commits\n",
+      "commons-lang                   has 225 commits\n",
+      "commons-net                    has 176 commits\n",
+      "commons-validator              has  75 commits\n",
+      "commons-vfs                    has 118 commits\n",
+      "giraph                         has 146 commits\n",
+      "gora                           has  98 commits\n",
+      "parquet-mr                     has 119 commits\n",
+      "wss4j                          has 245 commits\n",
+      "deltaspike                     has   8 commits\n",
+      "systemml                       has   6 commits\n",
+      "jspwiki                        has   1 commits\n",
+      "eagle                          has   2 commits\n",
+      "santuario-java                 has  95 commits\n",
+      "commons-imaging                has  20 commits\n",
+      "commons-scxml                  has  67 commits\n"
+     ]
+    }
+   ],
    "source": [
-    "**TODO** copy contents from `01-compare_annotations.ipynb`"
+    "smartshark_projects_shas = {}\n",
+    "for project in smartshark_projects:\n",
+    "    print(f\"{project:30s} has \", end=\"\")\n",
+    "\n",
+    "    smartshark_projects_shas[project] = smartshark_commits_df[smartshark_commits_df['project'] == project]['revision_hash'].unique()\n",
+    "    print(f\"{len(smartshark_projects_shas[project]):3d} commits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 159,
+   "id": "e8bc5cf8-9de0-4665-96d9-a9685be5e1f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3519"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sum([len(shas) for shas in smartshark_projects_shas.values()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "id": "72286121-3455-4b54-9bf8-99f682a3c964",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3519, 4)"
+      ]
+     },
+     "execution_count": 160,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smartshark_commits_df.shape"
    ]
   },
   {
@@ -3009,11 +3094,217 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 161,
+   "id": "486aa284-d575-4ca0-ad86-effc356628ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "most_common\n",
+       "test             115073\n",
+       "bugfix            73068\n",
+       "documentation     40650\n",
+       "whitespace        11937\n",
+       "refactoring        5297\n",
+       "unrelated          1341\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smartshark_df[smartshark_df['has_consensus']]['most_common'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "id": "5d5b7ac6-4032-47ae-9e54-404e27ff185c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "most_common\n",
+       "test             0.465193\n",
+       "bugfix           0.295384\n",
+       "documentation    0.164331\n",
+       "whitespace       0.048256\n",
+       "refactoring      0.021414\n",
+       "unrelated        0.005421\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 162,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smartshark_df[smartshark_df['has_consensus']]['most_common'].value_counts()/smartshark_df['has_consensus'].sum()"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "5dab56a4-1da7-4103-a8c4-e3eee7805c28",
+   "id": "bd4c8f5b-8fed-48b8-8f69-9ed6c00ed5cc",
    "metadata": {},
    "source": [
-    "**TODO** copy contents from `01-compare_annotations.ipynb`"
+    "We need to decide on how `diff-annotate` is to annotate lines, what possible line types we can assign.\n",
+    "\n",
+    "PatchScope does not implement refactoring detection - it is out of scope of the project (for now?).  This means that it would not assign the \"refactoring\" label (5297 = 2.14%).  Similarly, we would not be able to assign the \"unrelated\" label (1341 = 0.54%).\n",
+    "\n",
+    "Currently PatchScope cannot detect whitespace-only **_changes_** (11937 = 4.83%), as it currently does not do any matching between removed and added lines.  We can however assign \"whitespace\" label to whitespace-only _lines_... but we need to check if it improves agreement or not.\n",
+    "\n",
+    "The paper does not say whether documentation in test should be labelled \"documentation\" or \"test\".  We can try either way.\n",
+    "\n",
+    "Most probably comments in the code should be considered \"documentation\", and changes that are not comments to a file in programming language should be considered \"bugfix\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e39af87-f1f3-441f-bd88-86d3298aeb18",
+   "metadata": {},
+   "source": [
+    "It turns out (see `'01-compare_annotations.ipynb'`) that we do not need to write special line callback code for SmartSHARK-compatibile labelling; adjusting the rules with command line arguments like `--purpose-to-annotation` and a bit of post-processing would be a better solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "fe4f2725-e8a5-49f8-b39d-9d1735db0993",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f287f528-a3ff-4333-ab42-92e63cca5490",
+   "metadata": {},
+   "source": [
+    "Next step is generate the script that would run `diff-annotate from-repo` on SmartSHARK repos for SmartSHARK commits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "id": "60f9dfa9-6c69-450d-b76c-af4c13f6e485",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_smartshark_script = '../../run_annotation_smartshark_repos.sh'\n",
+    "smartshark_callback_file_relative = 'smartshark_line_callback.py'  # relative to script workdir\n",
+    "smartshark_repos_dir = '/mnt/data/msr/smartshark_repositories'  # NOTE: this is value for this local computer (!!!)\n",
+    "smartshark_annotations_dir = '/mnt/data/python-diff-annotator/example_annotations/smartshark'  # NOTE: configure this\n",
+    "\n",
+    "# creating part 1 of 2 of the script\n",
+    "with open(run_smartshark_script, 'wt') as fp:\n",
+    "    print('#!/usr/bin/sh', file=fp)\n",
+    "    print('', file=fp)\n",
+    "    print(f'CALLBACK_FILE=\"{smartshark_callback_file_relative}\"', file=fp)\n",
+    "    print(f'REPOS_DIR=\"{smartshark_repos_dir}\"', file=fp)\n",
+    "    print(f'ANNOTATIONS_DIR=\"{smartshark_annotations_dir}\"', file=fp)\n",
+    "    print('', file=fp)\n",
+    "    print('if [ ! -f \"$CALLBACK_FILE\" ]; then', file=fp)\n",
+    "    print('    echo \"Could not find file $CALLBACK_FILE\"', file=fp)\n",
+    "    print('    echo \"You are in directory $PWD\"', file=fp)\n",
+    "    print('    echo \"Change directory to the top dir of this repo $(git rev-parse --show-toplevel 2>/dev/null)\"', file=fp)\n",
+    "    print('    exit 1', file=fp)\n",
+    "    print('fi', file=fp)\n",
+    "    print('if [ ! -d \"$REPOS_DIR\" ]; then', file=fp)\n",
+    "    print('    echo \"Could not find directory $REPOS_DIR\"', file=fp)\n",
+    "    print('    exit 2', file=fp)\n",
+    "    print('fi', file=fp)\n",
+    "    print('', file=fp)\n",
+    "    print('echo \"running annotations on SmartSHARK repos for SmartSHARK buggy commits, v2\"', file=fp)\n",
+    "    print('echo \"trying to generate the same line annotations as used by SmartSHARK dataset\"', file=fp)\n",
+    "    print('echo \"saving annotations to $ANNOTATIONS_DIR\"', file=fp)\n",
+    "    print('', file=fp)\n",
+    "\n",
+    "Path(run_smartshark_script).chmod(0o755)  # 0755/-rwxr-xr-x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "254034c6-3a96-4984-8f8d-e3a3607cdae4",
+   "metadata": {},
+   "source": [
+    "One thing to consider is whether to use `--use-fanout` option, or not.  We opted to not use it, for easier annotation-parsing code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "7b1639d9-b439-420d-9aa1-cf18542cf989",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ant-ivy             \targ_length <= 22831\n",
+      "commons-math        \targ_length <= 16404\n",
+      "opennlp             \targ_length <= 6513\n",
+      "archiva             \targ_length <= 568\n",
+      "commons-bcel        \targ_length <= 2505\n",
+      "commons-beanutils   \targ_length <= 2884\n",
+      "commons-codec       \targ_length <= 2753\n",
+      "commons-collections \targ_length <= 4159\n",
+      "commons-compress    \targ_length <= 8745\n",
+      "commons-configuration\targ_length <= 10764\n",
+      "commons-dbcp        \targ_length <= 4022\n",
+      "commons-digester    \targ_length <= 1447\n",
+      "commons-io          \targ_length <= 5125\n",
+      "commons-jcs         \targ_length <= 3364\n",
+      "commons-lang        \targ_length <= 9598\n",
+      "commons-net         \targ_length <= 7587\n",
+      "commons-validator   \targ_length <= 3458\n",
+      "commons-vfs         \targ_length <= 5209\n",
+      "giraph              \targ_length <= 6347\n",
+      "gora                \targ_length <= 4375\n",
+      "parquet-mr          \targ_length <= 5248\n",
+      "wss4j               \targ_length <= 10404\n",
+      "deltaspike          \targ_length <= 697\n",
+      "systemml            \targ_length <= 611\n",
+      "jspwiki             \targ_length <= 404\n",
+      "eagle               \targ_length <= 441\n",
+      "santuario-java      \targ_length <= 4272\n",
+      "commons-imaging     \targ_length <= 1199\n",
+      "commons-scxml       \targ_length <= 3122\n"
+     ]
+    }
+   ],
+   "source": [
+    "# creating part 2 of 2 of the script\n",
+    "for repo_name, repo_shas in smartshark_projects_shas.items():\n",
+    "    print(f\"{repo_name:20s}\", end='')\n",
+    "    cmd_str = ''.join([\n",
+    "        'diff-annotate ',\n",
+    "        '--ext-to-language=\".pom:Maven POM\" ',\n",
+    "        '--ext-to-language=\".plist:XML Property List\" ',\n",
+    "        '--ext-to-language=\".jar:Java Archive\" ',\n",
+    "        '--pattern-to-purpose=\"*.jar:other\" ',\n",
+    "        '--filename-to-language=RELEASE_NOTES:Text ',\n",
+    "        # OLD VERSION\n",
+    "        #f'--line-callback=\"$CALLBACK_FILE\" ',\n",
+    "        # NEW VERSION\n",
+    "        '--purpose-to-annotation=test ',\n",
+    "        '--purpose-to-annotation=documentation ',\n",
+    "        'from-repo ',\n",
+    "        f'--output-dir=\"$ANNOTATIONS_DIR/{repo_name}\" ',\n",
+    "        f'\"$REPOS_DIR/{repo_name}\" --no-walk=sorted {\" \".join(repo_shas)}',\n",
+    "    ])\n",
+    "    print(\"\\targ_length <=\", len(cmd_str))\n",
+    "    \n",
+    "    with open(run_smartshark_script, 'at') as fp:\n",
+    "        print(f\"# {repo_name}\", file=fp)\n",
+    "        print(cmd_str, file=fp)"
    ]
   },
   {
@@ -3070,7 +3361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 169,
    "id": "7bb6ced1-1c34-4fe3-8e12-78c5ef0fad2a",
    "metadata": {},
    "outputs": [
@@ -3079,37 +3370,37 @@
      "output_type": "stream",
      "text": [
       "ant-ivy                548 commits, 2766 changed files, 43348 changed lines\n",
-      "archiva                5 commits, 62 changed files, 1941 changed lines\n",
-      "commons-bcel           52 commits, 185 changed files, 4472 changed lines\n",
-      "commons-beanutils      61 commits, 131 changed files, 4746 changed lines\n",
-      "commons-codec          58 commits, 167 changed files, 5145 changed lines\n",
-      "commons-collections    92 commits, 283 changed files, 6412 changed lines\n",
-      "commons-compress       204 commits, 523 changed files, 8806 changed lines\n",
-      "commons-configuration  253 commits, 853 changed files, 22563 changed lines\n",
-      "commons-dbcp           89 commits, 268 changed files, 6811 changed lines\n",
-      "commons-digester       26 commits, 76 changed files, 1400 changed lines\n",
-      "commons-imaging        20 commits, 58 changed files, 1024 changed lines\n",
-      "commons-io             116 commits, 232 changed files, 5226 changed lines\n",
-      "commons-jcs            73 commits, 451 changed files, 15640 changed lines\n",
-      "commons-lang           225 commits, 495 changed files, 11443 changed lines\n",
+      "archiva                  5 commits,   62 changed files,  1941 changed lines\n",
+      "commons-bcel            52 commits,  185 changed files,  4472 changed lines\n",
+      "commons-beanutils       61 commits,  131 changed files,  4746 changed lines\n",
+      "commons-codec           58 commits,  167 changed files,  5145 changed lines\n",
+      "commons-collections     92 commits,  283 changed files,  6412 changed lines\n",
+      "commons-compress       204 commits,  523 changed files,  8806 changed lines\n",
+      "commons-configuration  253 commits,  853 changed files, 22563 changed lines\n",
+      "commons-dbcp            89 commits,  268 changed files,  6811 changed lines\n",
+      "commons-digester        26 commits,   76 changed files,  1400 changed lines\n",
+      "commons-imaging         20 commits,   58 changed files,  1024 changed lines\n",
+      "commons-io             116 commits,  232 changed files,  5226 changed lines\n",
+      "commons-jcs             73 commits,  451 changed files, 15640 changed lines\n",
+      "commons-lang           225 commits,  495 changed files, 11443 changed lines\n",
       "commons-math           391 commits, 1396 changed files, 42796 changed lines\n",
-      "commons-net            176 commits, 368 changed files, 6099 changed lines\n",
-      "commons-scxml          67 commits, 307 changed files, 6066 changed lines\n",
-      "commons-validator      75 commits, 176 changed files, 2615 changed lines\n",
-      "commons-vfs            118 commits, 297 changed files, 5799 changed lines\n",
-      "deltaspike             8 commits, 15 changed files, 155 changed lines\n",
-      "eagle                  2 commits, 3 changed files, 50 changed lines\n",
-      "giraph                 146 commits, 570 changed files, 15302 changed lines\n",
-      "gora                   98 commits, 356 changed files, 10748 changed lines\n",
-      "jspwiki                1 commits, 2 changed files, 120 changed lines\n",
-      "opennlp                150 commits, 405 changed files, 7610 changed lines\n",
-      "parquet-mr             119 commits, 435 changed files, 15973 changed lines\n",
-      "santuario-java         0 commits, 0 changed files, 0 changed lines\n",
-      "systemml               6 commits, 9 changed files, 225 changed lines\n",
-      "wss4j                  0 commits, 0 changed files, 0 changed lines\n",
+      "commons-net            176 commits,  368 changed files,  6099 changed lines\n",
+      "commons-scxml           67 commits,  307 changed files,  6066 changed lines\n",
+      "commons-validator       75 commits,  176 changed files,  2615 changed lines\n",
+      "commons-vfs            118 commits,  297 changed files,  5799 changed lines\n",
+      "deltaspike               8 commits,   15 changed files,   155 changed lines\n",
+      "eagle                    2 commits,    3 changed files,    50 changed lines\n",
+      "giraph                 146 commits,  570 changed files, 15302 changed lines\n",
+      "gora                    98 commits,  356 changed files, 10748 changed lines\n",
+      "jspwiki                  1 commits,    2 changed files,   120 changed lines\n",
+      "opennlp                150 commits,  405 changed files,  7610 changed lines\n",
+      "parquet-mr             119 commits,  435 changed files, 15973 changed lines\n",
+      "santuario-java           0 commits,    0 changed files,     0 changed lines\n",
+      "systemml                 6 commits,    9 changed files,   225 changed lines\n",
+      "wss4j                    0 commits,    0 changed files,     0 changed lines\n",
       "\n",
-      "CPU times: user 1.46 s, sys: 120 ms, total: 1.58 s\n",
-      "Wall time: 1.57 s\n"
+      "CPU times: user 1.55 s, sys: 51.7 ms, total: 1.6 s\n",
+      "Wall time: 1.6 s\n"
      ]
     }
    ],
@@ -3189,17 +3480,267 @@
     "                        'purpose': line_data['purpose'],\n",
     "                    })\n",
     "\n",
-    "    print(f\" {n_commits} commits, {n_files} changed files, {n_lines} changed lines\")\n",
+    "    print(f\" {n_commits:3d} commits, {n_files:4d} changed files, {n_lines:5d} changed lines\")\n",
     "\n",
     "print(\"\")"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 170,
+   "id": "6f8f8cd9-c540-4a3f-ab33-1602a9a8cb19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ant-ivy                548 commits\n",
+      "archiva                  5 commits\n",
+      "commons-bcel            52 commits\n",
+      "commons-beanutils       61 commits\n",
+      "commons-codec           58 commits\n",
+      "commons-collections     92 commits\n",
+      "commons-compress       204 commits\n",
+      "commons-configuration  253 commits\n",
+      "commons-dbcp            89 commits\n",
+      "commons-digester        26 commits\n",
+      "commons-imaging         20 commits\n",
+      "commons-io             116 commits\n",
+      "commons-jcs             73 commits\n",
+      "commons-lang           225 commits\n",
+      "commons-math           391 commits\n",
+      "commons-net            176 commits\n",
+      "commons-scxml           67 commits\n",
+      "commons-validator       75 commits\n",
+      "commons-vfs            118 commits\n",
+      "deltaspike               8 commits\n",
+      "eagle                    2 commits\n",
+      "giraph                 146 commits\n",
+      "gora                    98 commits\n",
+      "jspwiki                  1 commits\n",
+      "opennlp                150 commits\n",
+      "parquet-mr             119 commits\n",
+      "santuario-java          95 commits\n",
+      "systemml                 6 commits\n",
+      "wss4j                  245 commits\n"
+     ]
+    }
+   ],
+   "source": [
+    "for project in sorted(smartshark_projects):\n",
+    "    print(f\"{project:22s} {len(smartshark_projects_shas[project]):3d} commits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "5757d887-23e6-4851-a0b2-f2dcbbb8cf0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ant-ivy                548 commits smartshark, 548 commits from-repo\n",
+      "archiva                  5 commits smartshark,   5 commits from-repo\n",
+      "commons-bcel            52 commits smartshark,  52 commits from-repo\n",
+      "commons-beanutils       61 commits smartshark,  61 commits from-repo\n",
+      "commons-codec           58 commits smartshark,  58 commits from-repo\n",
+      "commons-collections     92 commits smartshark,  92 commits from-repo\n",
+      "commons-compress       204 commits smartshark, 204 commits from-repo\n",
+      "commons-configuration  253 commits smartshark, 253 commits from-repo\n",
+      "commons-dbcp            89 commits smartshark,  89 commits from-repo\n",
+      "commons-digester        26 commits smartshark,  26 commits from-repo\n",
+      "commons-imaging         20 commits smartshark,  20 commits from-repo\n",
+      "commons-io             116 commits smartshark, 116 commits from-repo\n",
+      "commons-jcs             73 commits smartshark,  73 commits from-repo\n",
+      "commons-lang           225 commits smartshark, 225 commits from-repo\n",
+      "commons-math           391 commits smartshark, 391 commits from-repo\n",
+      "commons-net            176 commits smartshark, 176 commits from-repo\n",
+      "commons-scxml           67 commits smartshark,  67 commits from-repo\n",
+      "commons-validator       75 commits smartshark,  75 commits from-repo\n",
+      "commons-vfs            118 commits smartshark, 118 commits from-repo\n",
+      "deltaspike               8 commits smartshark,   8 commits from-repo\n",
+      "eagle                    2 commits smartshark,   2 commits from-repo\n",
+      "giraph                 146 commits smartshark, 146 commits from-repo\n",
+      "gora                    98 commits smartshark,  98 commits from-repo\n",
+      "jspwiki                  1 commits smartshark,   1 commits from-repo\n",
+      "opennlp                150 commits smartshark, 150 commits from-repo\n",
+      "parquet-mr             119 commits smartshark, 119 commits from-repo\n",
+      "santuario-java          95 commits smartshark,   0 commits from-repo *\n",
+      "systemml                 6 commits smartshark,   6 commits from-repo\n",
+      "wss4j                  245 commits smartshark,   0 commits from-repo *\n"
+     ]
+    }
+   ],
+   "source": [
+    "projects_to_drop = []\n",
+    "\n",
+    "for project in sorted(smartshark_projects):\n",
+    "    n_commits_smartshark = len(smartshark_projects_shas[project])\n",
+    "    print(f\"{project:22s} {n_commits_smartshark:3d} commits smartshark,\", end='')\n",
+    "    if Path(smartshark_annotations_dir).joinpath(project).is_dir():\n",
+    "        n_commits_from_repo = len(list(Path(smartshark_annotations_dir).joinpath(project).glob('*.json')))\n",
+    "        print(f\" {n_commits_from_repo:3d} commits from-repo\", end='')\n",
+    "        if n_commits_smartshark != n_commits_from_repo:\n",
+    "            projects_to_drop.append(project)\n",
+    "            print(\" *\")\n",
+    "        else:\n",
+    "            print(\"\")\n",
+    "    else:\n",
+    "        print(\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "id": "6c469db4-ad00-4854-80dd-dc467097c679",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['santuario-java', 'wss4j']"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(projects_to_drop)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "3bfb7fc7-433a-42b9-bb0e-24382bdb572c",
+   "id": "680a1d3d-29a0-40e9-8d7b-6a4bf5aa0fad",
    "metadata": {},
    "source": [
-    "**TODO** copy comparison of number of commits per repo for SmartSHARK data, and for PatchScope (`diff-annotate`) annotations"
+    "Check random commit from one of those repositories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "id": "9768543f-21b2-4f9f-b2e1-ccaef60de6c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>project</th>\n",
+       "      <th>repository_url</th>\n",
+       "      <th>issue_id</th>\n",
+       "      <th>revision_hash</th>\n",
+       "      <th>file</th>\n",
+       "      <th>hunk_id</th>\n",
+       "      <th>old_start</th>\n",
+       "      <th>old_lines</th>\n",
+       "      <th>new_start</th>\n",
+       "      <th>new_lines</th>\n",
+       "      <th>...</th>\n",
+       "      <th>user_atuz</th>\n",
+       "      <th>user_JG</th>\n",
+       "      <th>user_yyh</th>\n",
+       "      <th>user_LuCH</th>\n",
+       "      <th>user_LeBron</th>\n",
+       "      <th>user_Mohammad</th>\n",
+       "      <th>most_common</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>common_count</th>\n",
+       "      <th>has_consensus</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>280116</th>\n",
+       "      <td>santuario-java</td>\n",
+       "      <td>https://github.com/apache/santuario-java.git</td>\n",
+       "      <td>SANTUARIO-499</td>\n",
+       "      <td>88876f7a6736476c4f61a0bf100180c08576da7c</td>\n",
+       "      <td>src/test/java/org/apache/xml/security/test/dom...</td>\n",
+       "      <td>5caee5994dd2d957413f018f</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>75</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 83 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               project                                repository_url  \\\n",
+       "280116  santuario-java  https://github.com/apache/santuario-java.git   \n",
+       "\n",
+       "             issue_id                             revision_hash  \\\n",
+       "280116  SANTUARIO-499  88876f7a6736476c4f61a0bf100180c08576da7c   \n",
+       "\n",
+       "                                                     file  \\\n",
+       "280116  src/test/java/org/apache/xml/security/test/dom...   \n",
+       "\n",
+       "                         hunk_id  old_start  old_lines  new_start  new_lines  \\\n",
+       "280116  5caee5994dd2d957413f018f          0          0          1         75   \n",
+       "\n",
+       "        ...  user_atuz user_JG user_yyh  user_LuCH user_LeBron user_Mohammad  \\\n",
+       "280116  ...        NaN     NaN      NaN        NaN         NaN           NaN   \n",
+       "\n",
+       "       most_common n_reviewers common_count has_consensus  \n",
+       "280116        test           4          3.0          True  \n",
+       "\n",
+       "[1 rows x 83 columns]"
+      ]
+     },
+     "execution_count": 173,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smartshark_df[smartshark_df['project'] == projects_to_drop[0]].head(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d89e05ad-2cea-4e50-9c12-da378c19afc5",
+   "metadata": {},
+   "source": [
+    "Lets check https://github.com/apache/santuario-java/commit/88876f7a6736476c4f61a0bf100180c08576da7c\n",
+    "\n",
+    "GitHub gives the following warning:\n",
+    "> This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository."
    ]
   },
   {
@@ -3210,7 +3751,7 @@
    "outputs": [],
    "source": [
     "# Copied from 01-compare_annotations.ipynb\n",
-    "projects_to_drop = ['santuario-java', 'wss4j']"
+    "#projects_to_drop = ['santuario-java', 'wss4j']"
    ]
   },
   {

--- a/notebooks/experiments/02-compare_annotations_Herbold.ipynb
+++ b/notebooks/experiments/02-compare_annotations_Herbold.ipynb
@@ -4684,7 +4684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 153,
    "id": "492d6d22-3d0f-494e-b6fa-8f031723f06f",
    "metadata": {},
    "outputs": [
@@ -4692,25 +4692,25 @@
      "data": {
       "text/plain": [
        "indicator_column\n",
-       "both          237393\n",
-       "left_only      53419\n",
-       "right_only     15142\n",
+       "both          203727\n",
+       "right_only     48808\n",
+       "left_only      43639\n",
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "indicator_value_counts_s_sel = smartshark_vs_from_repos_df_merge['indicator_column'].value_counts()\n",
+    "indicator_value_counts_s_sel = smartshark_vs_from_repos_df_merge_sel['indicator_column'].value_counts()\n",
     "indicator_value_counts_s_sel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 154,
    "id": "8337217b-aa88-48e7-907d-8f0039aff0dd",
    "metadata": {},
    "outputs": [
@@ -4718,13 +4718,13 @@
      "data": {
       "text/plain": [
        "indicator_column\n",
-       "both          0.959683\n",
-       "left_only     0.215951\n",
-       "right_only    0.061213\n",
+       "both          0.823585\n",
+       "right_only    0.197311\n",
+       "left_only     0.176415\n",
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4735,7 +4735,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 156,
    "id": "df10156c-97f9-4951-95db-ab87ff043ab0",
    "metadata": {},
    "outputs": [
@@ -4743,13 +4743,13 @@
      "data": {
       "text/plain": [
        "indicator_column\n",
-       "both          0.940040\n",
-       "left_only     0.211531\n",
-       "right_only    0.059960\n",
+       "both          0.806728\n",
+       "right_only    0.193272\n",
+       "left_only     0.172804\n",
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4760,7 +4760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 155,
    "id": "16324157-190d-411a-9e26-02403c80c086",
    "metadata": {},
    "outputs": [
@@ -4775,7 +4775,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6036,6 +6036,14 @@
     "print(res.confidence_interval)\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd7f615-d813-409f-8914-e36aebda6165",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/experiments/02-compare_annotations_Herbold.ipynb
+++ b/notebooks/experiments/02-compare_annotations_Herbold.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 2,
    "id": "468fcf1e-7ed4-48f7-a303-89ddcb61e6ff",
    "metadata": {},
    "outputs": [],
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "a381cfc4-1c5d-488e-aa58-d40b09a46396",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d1698b29-bd9c-4b18-9b58-10cb5bcf5ea0",
    "metadata": {},
    "outputs": [],
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "fd510a5e-661e-4e89-9891-dd072ce6e26a",
    "metadata": {},
    "outputs": [],
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "356916df-0e48-4418-bfd7-fd37ae5a7032",
    "metadata": {},
    "outputs": [
@@ -150,7 +150,7 @@
        "list"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "a5c51c6a-98b8-4c82-bb3d-f4407a07ba32",
    "metadata": {},
    "outputs": [],
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a7611134-c824-4fbd-928a-3391c61a31a6",
    "metadata": {},
    "outputs": [
@@ -200,7 +200,7 @@
        " '5a82f5aa912063217b88940e']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "0f60f661-e14c-4830-9233-fc18225bbdcc",
    "metadata": {},
    "outputs": [
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "8ab4b012-f263-4c06-a5ed-ba61a00cb444",
    "metadata": {},
    "outputs": [],
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "ce721b8f-f3e9-403b-9f39-40db3ebe3d13",
    "metadata": {},
    "outputs": [
@@ -250,8 +250,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "44.8 ns ± 0.257 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n",
-      "22.6 ns ± 0.239 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n"
+      "43.4 ns ± 0.236 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n",
+      "22.3 ns ± 0.047 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)\n"
      ]
     }
    ],
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "eca8e83e-608f-41d3-9f0e-271881e03929",
    "metadata": {},
    "outputs": [],
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c63260a6-775f-4e90-8516-ded88b4821a7",
    "metadata": {},
    "outputs": [
@@ -324,7 +324,7 @@
        "'mongodb://localhost:37017'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -336,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "e2e97633-c21f-4f29-8a96-f4a32ef8317a",
    "metadata": {},
    "outputs": [
@@ -346,7 +346,7 @@
        "MongoClient(host=['localhost:37017'], document_class=dict, tz_aware=False, connect=True, read_preference=Primary())"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "07f0ae57-76cb-423a-9922-ab11fc6d185d",
    "metadata": {},
    "outputs": [
@@ -376,7 +376,7 @@
        "SON([('_id', ObjectId('5a82f5ab912063217d88943b')), ('file_action_id', ObjectId('58c898ebc03bb4351fbcad44')), ('new_start', 110), ('new_lines', 4), ('old_start', 109), ('old_lines', 2), ('content', '-        BufferedReader r = new BufferedReader(new InputStreamReader(URLHandlerRegistry.getDefault()\\n-                .openStream(url)));\\n+        URLHandler urlHandler = URLHandlerRegistry.getDefault();\\n+        String charset = urlHandler.getURLInfo(url).getBodyCharset();\\n+        InputStream contentStream = urlHandler.openStream(url);\\n+        BufferedReader r = new BufferedReader(new InputStreamReader(contentStream, charset));\\n'), ('lines_manual', {'sherbold': {'bugfix': [0, 1, 2, 3, 4, 5]}, 'riruk': {'refactoring': [0, 1, 4, 5], 'bugfix': [2, 3]}, 'aaghamohammadi': {'bugfix': [0, 1, 2, 3, 4, 5]}, 'omalam': {'refactoring': [0, 1, 4, 5], 'bugfix': [2, 3]}}), ('lines_verified', {'None': [0, 1, 4, 5], 'bugfix': [2, 3]}), ('uncorrected_lines_manual', {})])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "fe53933f-1123-4354-ac6b-f80cfa738792",
    "metadata": {},
    "outputs": [
@@ -397,7 +397,7 @@
        "ObjectId('5a82f5ab912063217d88943b')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "d4737998-7c43-454d-8d95-90cac43e7fd9",
    "metadata": {},
    "outputs": [
@@ -419,7 +419,7 @@
        "'5a82f5ab912063217d88943b'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "eafda194-861c-4929-a356-8585c61d62f9",
    "metadata": {},
    "outputs": [
@@ -443,7 +443,7 @@
        " 'omalam': {'refactoring': [0, 1, 4, 5], 'bugfix': [2, 3]}}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "4ef56509-d269-41cc-b313-5743ba36680c",
    "metadata": {},
    "outputs": [
@@ -464,7 +464,7 @@
        "{'None': [0, 1, 4, 5], 'bugfix': [2, 3]}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "92f8bbc3-5e26-4f0d-948b-0265088cd88d",
    "metadata": {},
    "outputs": [
@@ -490,7 +490,7 @@
        " '+        BufferedReader r = new BufferedReader(new InputStreamReader(contentStream, charset));']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "1a92fb5b-db87-4279-8985-5cf446745d85",
    "metadata": {},
    "outputs": [
@@ -535,7 +535,7 @@
        " '+']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -568,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "21570244-22e1-47e8-b095-d6a9c2883105",
    "metadata": {},
    "outputs": [
@@ -578,7 +578,7 @@
        "{0: 0, 1: 1, 5: 3, 8: 5, 11: 7}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "189e33b3-d7e2-421c-aef3-e81a62f69adb",
    "metadata": {},
    "outputs": [
@@ -603,7 +603,7 @@
        " '-     ']"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -614,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "811e68e0-b3e7-4da7-94ef-abca0ea493f4",
    "metadata": {},
    "outputs": [
@@ -666,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "4ff22d7e-5546-4e37-b20c-5e59a27bdbed",
    "metadata": {},
    "outputs": [
@@ -747,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "7f1e8f66-2c74-48e6-a5b5-bfc8b790e3dd",
    "metadata": {},
    "outputs": [],
@@ -758,7 +758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "3abbdaa0-e29e-4d6f-b22e-14d2b9dc59ba",
    "metadata": {},
    "outputs": [],
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "ef6ea573-78f6-48fa-9a81-04288baad558",
    "metadata": {},
    "outputs": [
@@ -792,8 +792,9 @@
       "len(hunks_multi_issue)=0 (commits that link to multiple bugs)\n",
       "len(smartshark_records)=296348 lines (results of parsing)\n",
       "\n",
-      "CPU times: user 5min 58s, sys: 18 s, total: 6min 16s\n",
-      "Wall time: 7min 15s\n"
+      "CPU times: user 5min 55s, sys: 17.8 s, total: 6min 12s\n",
+      "Wall time: 7min 14s\n",
+      "Parser   : 120 ms\n"
      ]
     }
    ],
@@ -931,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "b1b839d5-cd89-443f-825a-d788687c3277",
    "metadata": {},
    "outputs": [
@@ -978,7 +979,7 @@
        "  'user_LDlnwznmYPWdNVSA': 'bugfix'}]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -989,7 +990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "0793b911-8b71-4fa2-805b-8c651d8ec5e6",
    "metadata": {},
    "outputs": [
@@ -1036,7 +1037,7 @@
        "  'user_bossenti': 'test'}]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1047,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "c1808899-7642-4446-b509-98604b85cfff",
    "metadata": {},
    "outputs": [],
@@ -1073,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "19e5a63a-4b38-4306-8756-c59c69e6c6a9",
    "metadata": {},
    "outputs": [],
@@ -1085,7 +1086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "cbfc91ac-dec7-46c7-b411-9e06f9cad636",
    "metadata": {},
    "outputs": [],
@@ -1109,7 +1110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 34,
    "id": "b43297e7-7ba7-4bdf-837a-be59094ea264",
    "metadata": {},
    "outputs": [],
@@ -1136,7 +1137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 35,
    "id": "67c1fb83-6528-433e-8225-49acccb4b50c",
    "metadata": {},
    "outputs": [],
@@ -1156,7 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 36,
    "id": "5f788d5c-a1c2-4cba-bbc9-585d949b204d",
    "metadata": {},
    "outputs": [
@@ -1186,7 +1187,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1197,7 +1198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 37,
    "id": "b3f79fd1-b5a9-46aa-b493-b521c849f7e1",
    "metadata": {},
    "outputs": [
@@ -1221,7 +1222,7 @@
        " 'lines_verified']"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1235,7 +1236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 38,
    "id": "40e16183-8d93-4461-8356-c0a42db0f3db",
    "metadata": {},
    "outputs": [
@@ -1245,7 +1246,7 @@
        "(296348, 79)"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1256,7 +1257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 39,
    "id": "005f170b-434d-4bc8-8557-8c83dda493e7",
    "metadata": {},
    "outputs": [
@@ -1281,7 +1282,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1310,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 40,
    "id": "a966b08b-a585-4018-a65a-96d9a157a580",
    "metadata": {},
    "outputs": [
@@ -1320,7 +1321,7 @@
        "np.int64(5536)"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1331,7 +1332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 41,
    "id": "2500ff3f-a80e-4dd0-93df-0b5e0b55f346",
    "metadata": {},
    "outputs": [
@@ -1659,7 +1660,7 @@
        "[5536 rows x 15 columns]"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1670,7 +1671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 42,
    "id": "506d0e03-c816-49b3-8831-1ca60e8e8cc8",
    "metadata": {},
    "outputs": [
@@ -1683,7 +1684,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1694,7 +1695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 43,
    "id": "f2dc6b67-76a9-41bb-913e-e871b130fa69",
    "metadata": {},
    "outputs": [
@@ -1707,7 +1708,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1718,7 +1719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 44,
    "id": "27ddbb21-91c3-4ba1-b895-daf50af9335b",
    "metadata": {},
    "outputs": [
@@ -1739,7 +1740,7 @@
        "Name: lines_verified, Length: 5536, dtype: object"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1750,7 +1751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 45,
    "id": "f228d190-0d0c-48dc-a368-a6cf478cd86d",
    "metadata": {},
    "outputs": [
@@ -1770,7 +1771,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1793,7 +1794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 46,
    "id": "72ac6a41-e419-41dd-9144-63245d930030",
    "metadata": {},
    "outputs": [],
@@ -1803,7 +1804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 47,
    "id": "9cb7943f-788a-4044-adba-2e5bc21b88a8",
    "metadata": {},
    "outputs": [
@@ -1822,7 +1823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 48,
    "id": "f621e401-dd0e-4fbc-b607-b53d260582e7",
    "metadata": {},
    "outputs": [
@@ -1832,7 +1833,7 @@
        "np.int64(290812)"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1852,7 +1853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 49,
    "id": "d161d883-a0fa-4e74-979a-9e5b5b88bcea",
    "metadata": {
     "scrolled": true
@@ -1927,7 +1928,7 @@
        " 'user_Mohammad']"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1938,7 +1939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 50,
    "id": "259ac3df-4d26-4529-bf43-2edff7a19a33",
    "metadata": {},
    "outputs": [],
@@ -1962,7 +1963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 51,
    "id": "24260c78-81d4-4835-932f-75b51b8d35ec",
    "metadata": {},
    "outputs": [],
@@ -1979,7 +1980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 52,
    "id": "eeea3405-22b6-4d3f-a03e-afed848e7e50",
    "metadata": {},
    "outputs": [],
@@ -2003,7 +2004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 53,
    "id": "985b8058-bdc1-43d8-8246-60fb68118cd6",
    "metadata": {},
    "outputs": [
@@ -2024,7 +2025,7 @@
        "Name: 0, Length: 79, dtype: object"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2036,7 +2037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 54,
    "id": "99773b57-e3a8-46d7-93c9-2aacae13ca63",
    "metadata": {},
    "outputs": [
@@ -2050,7 +2051,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2061,7 +2062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 55,
    "id": "5ea6a37b-e151-4932-bc37-c2a6b666769d",
    "metadata": {},
    "outputs": [
@@ -2071,7 +2072,7 @@
        "'whitespace'"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2082,7 +2083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 56,
    "id": "186ca88f-3a57-47f3-bd9c-e935bc94913f",
    "metadata": {},
    "outputs": [
@@ -2092,7 +2093,7 @@
        "4"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2103,7 +2104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 57,
    "id": "3004530a-1ca0-4001-b561-3d64bb5115bd",
    "metadata": {},
    "outputs": [
@@ -2113,7 +2114,7 @@
        "2"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2132,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 58,
    "id": "4836d1ca-c7c7-43df-b76f-fc096a7a8998",
    "metadata": {},
    "outputs": [
@@ -2153,7 +2154,7 @@
        "Name: 296061, Length: 79, dtype: object"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2165,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 59,
    "id": "fea3cec3-9410-45e6-b036-ad3ff65c21fa",
    "metadata": {},
    "outputs": [
@@ -2175,7 +2176,7 @@
        "Series([], Name: 296061, dtype: object)"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2186,8 +2187,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 60,
    "id": "213c2e35-23df-4c54-9e47-4632157b57d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<NA>"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "most_common_value(row_na)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "8f8eb57f-d9ff-4f0e-adbd-f3f1537aee66",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_reviewers(row_na)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "570c2efd-fe78-4066-8d3d-6a4a4f4ad9f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "nan"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "most_common_count(row_na)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "23cd8ff8-6de5-41b7-ba71-e0c18fbba42c",
    "metadata": {},
    "outputs": [
     {
@@ -2202,75 +2266,12 @@
     }
    ],
    "source": [
-    "most_common_value(row_na)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "id": "8f8eb57f-d9ff-4f0e-adbd-f3f1537aee66",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "n_reviewers(row_na)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
-   "id": "570c2efd-fe78-4066-8d3d-6a4a4f4ad9f5",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "nan"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "most_common_count(row_na)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "id": "23cd8ff8-6de5-41b7-ba71-e0c18fbba42c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<NA>"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
     "pd.NA"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 64,
    "id": "0d87f959-8f4e-4b76-aab1-9dc1037205c9",
    "metadata": {},
    "outputs": [
@@ -2280,7 +2281,7 @@
        "nan"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2299,7 +2300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 65,
    "id": "f867eb3e-4ae2-402c-a7b7-de30e8543f23",
    "metadata": {},
    "outputs": [
@@ -2307,8 +2308,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 27s, sys: 357 ms, total: 1min 27s\n",
-      "Wall time: 1min 27s\n"
+      "CPU times: user 1min 30s, sys: 350 ms, total: 1min 30s\n",
+      "Wall time: 1min 30s\n"
      ]
     },
     {
@@ -2338,7 +2339,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2375,7 +2376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 66,
    "id": "b80d03e9-b801-42be-ad8d-ea4eb04c9427",
    "metadata": {},
    "outputs": [
@@ -2390,7 +2391,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2401,7 +2402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 67,
    "id": "3c8d42e3-65f0-43cc-b816-399e28de18dd",
    "metadata": {},
    "outputs": [
@@ -2436,7 +2437,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2447,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 68,
    "id": "51f74193-380e-4ac8-88f1-b9370af0ee23",
    "metadata": {},
    "outputs": [
@@ -2464,7 +2465,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2483,7 +2484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 69,
    "id": "add0805c-5f7b-4098-a295-56ec239a04b3",
    "metadata": {},
    "outputs": [
@@ -2496,7 +2497,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2508,7 +2509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 70,
    "id": "94ded5f5-9e86-425f-a037-0f9de8908e8f",
    "metadata": {},
    "outputs": [
@@ -2521,7 +2522,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2540,7 +2541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 71,
    "id": "08ad7af6-8b6f-468c-a53c-d8487147da5c",
    "metadata": {},
    "outputs": [
@@ -2550,7 +2551,7 @@
        "np.int64(247366)"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2562,7 +2563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 72,
    "id": "fe5b2e97-1eb0-4aba-b939-5fc1fc1d428f",
    "metadata": {},
    "outputs": [
@@ -2572,7 +2573,7 @@
        "np.int64(247366)"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2584,7 +2585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 73,
    "id": "fca5f846-195f-4b32-b35b-a72422f9fe00",
    "metadata": {},
    "outputs": [
@@ -2594,7 +2595,7 @@
        "(247366, 83)"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2606,7 +2607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 74,
    "id": "9cf9123a-3074-48a1-9de8-aa5bda982dfa",
    "metadata": {},
    "outputs": [
@@ -2625,7 +2626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 75,
    "id": "b415825f-b3e2-4ce7-ace9-0274e4f3f099",
    "metadata": {},
    "outputs": [
@@ -2653,7 +2654,7 @@
        " 'has_consensus']"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2699,7 +2700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 76,
    "id": "804e3854-3040-407a-923f-b49fefa51a70",
    "metadata": {},
    "outputs": [
@@ -2843,7 +2844,7 @@
        "[3519 rows x 4 columns]"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2855,7 +2856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 77,
    "id": "0181ecd7-ea97-41c4-90f5-1b8ce2af1696",
    "metadata": {},
    "outputs": [
@@ -2872,7 +2873,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2884,7 +2885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 78,
    "id": "60533493-0106-4474-a730-fe4ba3eb4221",
    "metadata": {},
    "outputs": [
@@ -2894,7 +2895,7 @@
        "29"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2905,7 +2906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 79,
    "id": "206b33d1-681d-4feb-a98e-c01947bd7f89",
    "metadata": {
     "scrolled": true
@@ -2945,7 +2946,7 @@
        " 'wss4j']"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2956,7 +2957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 80,
    "id": "695678a1-6c4a-4e89-a47e-171f05f88842",
    "metadata": {},
    "outputs": [
@@ -2966,7 +2967,7 @@
        "set()"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2994,7 +2995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 81,
    "id": "bb87be0e-7172-4498-982b-b1a4b2ab8907",
    "metadata": {},
    "outputs": [
@@ -3045,7 +3046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 82,
    "id": "e8bc5cf8-9de0-4665-96d9-a9685be5e1f9",
    "metadata": {},
    "outputs": [
@@ -3055,7 +3056,7 @@
        "3519"
       ]
      },
-     "execution_count": 159,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3066,7 +3067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 83,
    "id": "72286121-3455-4b54-9bf8-99f682a3c964",
    "metadata": {},
    "outputs": [
@@ -3076,7 +3077,7 @@
        "(3519, 4)"
       ]
      },
-     "execution_count": 160,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3095,7 +3096,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 84,
    "id": "486aa284-d575-4ca0-ad86-effc356628ea",
    "metadata": {},
    "outputs": [
@@ -3112,7 +3113,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 161,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3123,7 +3124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 85,
    "id": "5d5b7ac6-4032-47ae-9e54-404e27ff185c",
    "metadata": {},
    "outputs": [
@@ -3140,7 +3141,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 162,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3175,7 +3176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 86,
    "id": "fe4f2725-e8a5-49f8-b39d-9d1735db0993",
    "metadata": {},
    "outputs": [],
@@ -3193,7 +3194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 87,
    "id": "60f9dfa9-6c69-450d-b76c-af4c13f6e485",
    "metadata": {},
    "outputs": [],
@@ -3240,7 +3241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 88,
    "id": "7b1639d9-b439-420d-9aa1-cf18542cf989",
    "metadata": {},
    "outputs": [
@@ -3330,7 +3331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 89,
    "id": "dcebcad0-b811-4c7a-ba61-53c84bc0be9d",
    "metadata": {},
    "outputs": [
@@ -3340,7 +3341,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/smartshark'"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3361,7 +3362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 90,
    "id": "7bb6ced1-1c34-4fe3-8e12-78c5ef0fad2a",
    "metadata": {},
    "outputs": [
@@ -3399,8 +3400,8 @@
       "systemml                 6 commits,    9 changed files,   225 changed lines\n",
       "wss4j                    0 commits,    0 changed files,     0 changed lines\n",
       "\n",
-      "CPU times: user 1.55 s, sys: 51.7 ms, total: 1.6 s\n",
-      "Wall time: 1.6 s\n"
+      "CPU times: user 1.48 s, sys: 92.2 ms, total: 1.58 s\n",
+      "Wall time: 1.57 s\n"
      ]
     }
    ],
@@ -3487,7 +3488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 91,
    "id": "6f8f8cd9-c540-4a3f-ab33-1602a9a8cb19",
    "metadata": {},
    "outputs": [
@@ -3534,7 +3535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 92,
    "id": "5757d887-23e6-4851-a0b2-f2dcbbb8cf0f",
    "metadata": {},
    "outputs": [
@@ -3594,7 +3595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 93,
    "id": "6c469db4-ad00-4854-80dd-dc467097c679",
    "metadata": {},
    "outputs": [
@@ -3604,7 +3605,7 @@
        "['santuario-java', 'wss4j']"
       ]
      },
-     "execution_count": 172,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3623,7 +3624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 94,
    "id": "9768543f-21b2-4f9f-b2e1-ccaef60de6c4",
    "metadata": {},
    "outputs": [
@@ -3723,7 +3724,7 @@
        "[1 rows x 83 columns]"
       ]
      },
-     "execution_count": 173,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3741,6 +3742,102 @@
     "\n",
     "GitHub gives the following warning:\n",
     "> This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bd385f4-b945-4855-b062-884d132f3085",
+   "metadata": {},
+   "source": [
+    "Let's examine how many commits, and how many lines it is"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "43d0436f-24be-42c5-a523-a14d7a5b32a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[95, 245]"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[len(smartshark_projects_shas[project]) for project in projects_to_drop]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "442b519f-4ee5-4ee2-9684-e9b65c073bb1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "340"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sum([len(smartshark_projects_shas[project]) for project in projects_to_drop])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "feb13b5f-6cce-43ab-8e67-5e52a5ca3570",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(36874, 83)"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "projects_to_drop_df = smartshark_df[\n",
+    "    (smartshark_df['project'] == projects_to_drop[0]) |\n",
+    "    (smartshark_df['project'] == projects_to_drop[1])\n",
+    "]\n",
+    "projects_to_drop_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "32c72752-a4a1-486b-993d-054d85054ba1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "340"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "projects_to_drop_df['revision_hash'].nunique()"
    ]
   },
   {


### PR DESCRIPTION
There were a few necessary pieces of data missing from `'notebooks/experiments/01-compare_annotations.ipynb'` and `'notebooks/experiments/02-compare_annotations_Herbold.ipynb'`.

This includes:
- finding the size of those 2 repositories in Herbold et al dataset for which we could not run `diff-annotate from-repo ...` on
- start exploration in mismatch between BugsInPy dataset (from HaPy-Bug) and results of `diff-annotate from-repo ...` on projects in it