### PR TITLE
Packaging: improve generating documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,10 @@
+# Reference documentation
+
+PatchScope consist of two independent but interrelated modules:
+
+- `diffannotator`, which is responsible for extracting patches or commits,
+  annotating changes (patches), and generating summaries of annotations
+- `diffinsights_web`, which is [Panel][]-based web app, that shows
+  generated summaries of annotations in a graphical way, as plots
+
+[Panel]: https://panel.holoviz.org/

--- a/docs/assets/optionalConfig.js
+++ b/docs/assets/optionalConfig.js
@@ -1,0 +1,217 @@
+// https://github.com/facelessuser/pymdown-extensions/blob/main/docs/src/markdown/.snippets/uml.md
+// PyMdown Extensions loader looks for `mermaidConfig` and will load the the appropriate
+// config based on our current scheme: light, dark, etc.
+window.mermaidConfig = {
+  dracula: {
+    startOnLoad: false,
+    theme: "base",
+    themeCSS: "\
+      {\
+        --drac-page-bg: hsl(233, 15%, 23%);\
+        --drac-white-fg: hsl(60, 30%, 96%);\
+        --drac-purple-fg: hsl(265, 89%, 78%);\
+        --drac-purple-bg: hsl(265, 25%, 39%);\
+        --drac-yellow-fg: hsl(65, 92%, 76%);\
+      }\
+      \
+      /* General */\
+      {\
+        background-color: var(--drac-page-bg);\
+      }\
+      \
+      /* Entity Relationship */\
+      defs marker#ZERO_OR_MORE_END circle {\
+        fill: var(--drac-page-bg) !important;\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ZERO_OR_MORE_END path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ZERO_OR_MORE_START circle{\
+        fill: var(--drac-page-bg) !important;\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ZERO_OR_MORE_START path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ONLY_ONE_START path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ONLY_ONE_END path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ZERO_OR_ONE_START path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ZERO_OR_ONE_END path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ONE_OR_MORE_START path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      defs marker#ONE_OR_MORE_END path {\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      \
+      /* Flowchart */\
+      .labelText,\
+      .label text {\
+        fill: var(--drac-purple-fg);\
+      }\
+      \
+      .edgeLabel text {\
+        fill: var(--drac-purple-fg) !important;\
+      }\
+      .edgeLabel rect {\
+        opacity: 0.5 !important;\
+        fill: var(--drac-purple-bg) !important;\
+      }\
+      \
+      /* Sequence */\
+      .noteText {\
+        fill: var(--drac-yellow-fg);\
+      }\
+      \
+      /* Gantt */\
+      .sectionTitle {\
+        fill: var(--drac-purple-fg) !important;\
+      }\
+      \
+      .grid .tick line {\
+        stroke: var(--drac-blue-fg) !important;\
+      }\
+      \
+      .grid .tick text {\
+        fill: var(--drac-purple-fg);\
+      }\
+      \
+      /* Class Diagram */\
+      .statediagram-state rect.divider {\
+        fill: transparent !important;\
+      }\
+      \
+      /* State Diagram */\
+      .stateGroup circle[style$=\"fill: black;\"] {\
+        fill: var(--drac-purple-bg) !important;\
+        stroke: var(--drac-purple-bg) !important;\
+      }\
+      \
+      .stateGroup circle[style$=\"fill: white;\"] {\
+        fill: var(--drac-purple-bg) !important;\
+        stroke: var(--drac-purple-fg) !important;\
+      }\
+      \
+      .stateGroup .composit {\
+        fill: var(--drac-page-bg);\
+      }\
+      /* Pie */\
+      text.slice {\
+        fill: var(--drac-white-fg) !important;\
+      }\
+      ",
+    themeVariables: {
+      darkMode: true,
+      background: "#323443",
+      mainBkg: "#604b7d",
+      textColor: "#bf95f9",
+      lineColor: "#bf95f9",
+      errorBkgColor: "#802c2c",
+      errorTextColor: "#ff5757",
+      primaryColor: "#604b7d",
+      primaryTextColor: "#bf95f9",
+      primaryBorderColor: "#bf95f9",
+      secondaryColor: "#297d3e",
+      secondaryTextColor: "#52fa7c",
+      secondaryBorderColor: "#52fa7c",
+      tertiaryColor: "#303952",
+      tertiaryTextColor: "#6071a4",
+      tertiaryBorderColor: "#6071a4",
+      noteBkgColor: "#797d45",
+      noteTextColor: "#f1fa89",
+      noteBorderColor: "#f1fa89",
+      edgeLabelBackground: "#604b7d",
+      edgeLabelText: "#604b7d",
+
+      actorLineColor: "#6071a4",
+
+      activeTaskBkgColor: "#803d63",
+      activeTaskBorderColor: "#ff7ac6",
+      doneTaskBkgColor: "#297d3e",
+      doneTaskBorderColor: "#52fa7c",
+      critBkgColor: "#802c2c",
+      critBorderColor: "#ff5757",
+      taskTextColor: "#bf95f9",
+      taskTextOutsideColor: "#bf95f9",
+      taskTextLightColor: "#bf95f9",
+      sectionBkgColor: "#bf95f9b3",
+      sectionBkgColor2: "#bf95f966",
+      altSectionBkgColor: "#323443",
+      todayLineColor: "#ff7ac6",
+      gridColor: "#6071a4",
+      defaultLinkColor: "#8be8fd",
+
+      altBackground: "#bf95f9",
+
+      classText: "#bf95f9",
+
+      fillType0: "#406080",
+      fillType1: "#46747f",
+      fillType2: "#297d3e",
+      fillType3: "#805c36",
+      fillType4: "#803d63",
+      fillType5: "#604b7d",
+      fillType6: "#802c2c",
+      fillType7: "#797d45",
+      fillType8: "#7c7c79"
+    },
+    flowchart: {
+      htmlLabels: false
+    },
+    er: {
+      useMaxWidth: false
+    },
+    sequence: {
+      useMaxWidth: false,
+      // Mermaid handles Firefox a little different.
+      // For some reason, it doesn't attach font sizes to the labels in Firefox.
+      // If we specify the documented defaults, font sizes are written to the labels in Firefox.
+      noteFontWeight: "14px",
+      actorFontSize: "14px",
+      messageFontSize: "16px"
+    }
+  },
+
+  default: {
+    startOnLoad: false,
+    theme: "default",
+    flowchart: {
+      htmlLabels: false
+    },
+    er: {
+      useMaxWidth: false
+    },
+    sequence: {
+      useMaxWidth: false,
+      noteFontWeight: "14px",
+      actorFontSize: "14px",
+      messageFontSize: "16px"
+    }
+  },
+
+  slate: {
+    startOnLoad: false,
+    theme: "dark",
+    flowchart: {
+      htmlLabels: false
+    },
+    er: {
+      useMaxWidth: false
+    },
+    sequence: {
+      useMaxWidth: false,
+      noteFontWeight: "14px",
+      actorFontSize: "14px",
+      messageFontSize: "16px"
+    }
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,8 @@ plugins:
         - scripts/gen_ref_pages.py
   - literate-nav:  # generate a literate navigation file for mkdocstrings pages
       nav_file: SUMMARY.md
-  - section-index  # bind pages to sections themselves in mkdocstrings pages
+  # NOTE: section-index is turned off, because it interfered with adding API docs for diffannotator
+  #- section-index  # bind pages to sections themselves in mkdocstrings pages
   # generating documentation from docstrings, now automatically
   - mkdocstrings:  # automatic documentation from sources for MkDocs
       default_handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,7 @@ plugins:
   #- auto
 
 extra_javascript:
-  - optionalConfig.js
+  - assets/optionalConfig.js
   - https://unpkg.com/mermaid@11.4.1/dist/mermaid.min.js
   # or https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js
-  - extra-loader.js
+  - assets/extra-loader.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,9 @@ nav:
   #- authors: authors.md
   #- history: history.md
   - CLI: cli.md
-  - API: reference/
+  - API:
+     - api.md
+     - reference/
   - schema: schema.md
   - examples: examples.md
   - notebooks: notebooks.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,13 +68,13 @@ markdown_extensions:
       generic: true
   - pymdownx.highlight:  # syntax highlighting of code blocks (with superfences)
       linenums: false
-  - pymdownx.superfences  #  arbitrary nesting of code and content blocks
-    #  preserve_tabs: true
-    #  custom_fences:
-    #    # Mermaid diagrams
-    #    - name: mermaid
-    #      class: mermaid
-    #      format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.superfences:  #  arbitrary nesting of code and content blocks
+      preserve_tabs: true
+      custom_fences:
+        # Mermaid diagrams
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details  # make admonition call-outs collapsible
   - pymdownx.tasklist:  #  GitHub Flavored Markdown inspired task lists
       custom_checkbox: true  # replace native checkbox styles with icons
@@ -137,7 +137,8 @@ plugins:
   #- UA-xxx
   #- auto
 
-#extra_javascript:
-#  - optionalConfig.js
-#  - https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.js
-#  - extra-loader.js
+extra_javascript:
+  - optionalConfig.js
+  - https://unpkg.com/mermaid@11.4.1/dist/mermaid.min.js
+  # or https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js
+  - extra-loader.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,9 +13,7 @@ nav:
   #- authors: authors.md
   #- history: history.md
   - CLI: cli.md
-  - API:
-     - api.md
-     - reference/
+  - API: reference/
   - schema: schema.md
   - examples: examples.md
   - notebooks: notebooks.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ doc = [
   #"setuptools~=68.0",
   #"pkginfo~=1.9",
   #"virtualenv~=20.0",
+  "black~=24.10.0",
 ]
 pylinguist = [
   "linguist@git+https://github.com/retanoj/linguist#egg=master",

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -32,4 +32,5 @@ for path in sorted(src.rglob("*.py")):
     #mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    print("* [Reference documentation](../api.md)", file=nav_file)
     nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
The project is configured so that GitHub Action generates MkDocs-powered documentation for the project on GitHub Pages, at the following URL: https://ncusi.github.io/PatchScope/

This series of patches improves generated documentation, but some parts are still quite raw,

- Removing the use of the `section-index` plugin made it to show automatically generated reference documentation both for 'diffnnotator' and diffinsights_web' packages; the former was previously missing
- Add support for Mermaid diagrams in documentation on GitHub Pages, instead of showing the code.

There are however still a few problems with generated documentation, that will be addressed in the future commits.