### PR TITLE
02-compare_annotations_Herbold.ipynb: Add output files to DVC storage

### DIFF
--- a/data/experiments/SmartSHARK/.gitignore
+++ b/data/experiments/SmartSHARK/.gitignore
@@ -1,0 +1,2 @@
+/herbold_from_repos.csv
+/herbold_line_labels.csv

--- a/data/experiments/SmartSHARK/herbold_from_repos.csv.dvc
+++ b/data/experiments/SmartSHARK/herbold_from_repos.csv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6914906058e2044c5a02ba9e2fc1bcf3
+  size: 40274199
+  hash: md5
+  path: herbold_from_repos.csv

--- a/data/experiments/SmartSHARK/herbold_line_labels.csv.dvc
+++ b/data/experiments/SmartSHARK/herbold_line_labels.csv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: f60847d99dc01d2f5e6e2423adba92d4
+  size: 108065985
+  hash: md5
+  path: herbold_line_labels.csv


### PR DESCRIPTION
Files generated by this Jupyter notebook are now saved in DVC storage, and *.dvc files (in 'data/experiments/SmartSHARK/') store references to that storage.

Those files are quite large, and 'herbold_line_labels.csv' in particular is larger than GitHub file size limit, having 104MB size.