### PR TITLE
Experiments - Add "Per line-type consensus (addition)" subsection to 'notebooks/experiments/01-compare_annotations.ipynb'

### DIFF
--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -36511,7 +36511,15 @@
    "id": "562068b5-0ad7-4489-9985-a14a4cd02a43",
    "metadata": {},
    "source": [
-    "#### Per line-type consensus (addition)"
+    "### Per line-type consensus (addition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a28827eb-811e-472e-87ea-e12aea030587",
+   "metadata": {},
+   "source": [
+    "#### per changed line, using most common type"
    ]
   },
   {
@@ -36880,6 +36888,14 @@
     "A: test,U: test + refactoring [91.6%],1.4249625977975622\n",
     "\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1075ab06-8d5b-4f22-853b-8449310a72e8",
+   "metadata": {},
+   "source": [
+    "#### per user annotation"
    ]
   },
   {
@@ -37660,6 +37676,14 @@
     "][\n",
     "    ['id','ds','file','image','line','bundle','user','annotation','n_reviewers','consensus','annotation == consensus']\n",
     "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fe1e561-9117-42e5-923a-b0e55a17af21",
+   "metadata": {},
+   "source": [
+    "#### per auto annotation (per changed line)"
    ]
   },
   {

--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -37688,6 +37688,1253 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fbd121c1-18ec-4115-b327-0b49b3e0bf07",
+   "metadata": {},
+   "source": [
+    "From reviewer #103C:\n",
+    "\n",
+    "> The authors report interesting results, indicating that only a small proportion of lines (≤ 6%) required manual intervention after automatic annotations. More details on the nature of these modifications would strengthen the analysis. Specifically, it would be helpful to know if the automatic annotations were primarily inaccurate in specific categories (e.g., documentation) or whether they lacked context for certain types of code changes. Since the automation relies on simple syntax rules, it might miss complex bug patterns, which requires further discussion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "731d4e74-e360-4c10-b8d9-874491a74d17",
+   "metadata": {},
+   "source": [
+    "Computing per-line consensus using **per automated entry data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "id": "5e529198-c069-4da6-a406-65e976a03f48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['ds', 'id', 'file', 'image', 'line', 'annotation_U1', 'annotation_U2',\n",
+       "       'annotation_U3', 'annotation_E1', 'annotation_E2', 'annotation_E3',\n",
+       "       'most_common', 'common_count', 'n_reviewers', 'consensus'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 215,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 216,
+   "id": "d8b7ffdb-4554-4f6d-8492-4b94b3834443",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['id', 'bundle', 'file', 'fcat', 'image', 'line', 'annotation', 'user',\n",
+       "       'auto', 'ds', 'bug'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 216,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "id": "be268b7e-a488-49ec-87aa-d540ab83d454",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "collective_df.shape=(391918, 11)\n",
+      "collective_df['auto'].sum()=np.int64(195953)\n",
+      "collective_df[collective_df['auto']].shape=(195953, 11)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{collective_df.shape=}\")\n",
+    "print(f\"{collective_df['auto'].sum()=}\")\n",
+    "print(f\"{collective_df[collective_df['auto']].shape=}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 221,
+   "id": "2d01948d-f05e-40a9-ac1e-4760e6418300",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(145269, 15)"
+      ]
+     },
+     "execution_count": 221,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 242,
+   "id": "ef178724-af08-42b3-bfc4-850528e23b00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(169390, 11)"
+      ]
+     },
+     "execution_count": 242,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df[collective_df['auto']].drop_duplicates().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 243,
+   "id": "88f32a77-fa07-447d-befc-4ec93e5c9348",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(57918, 11)"
+      ]
+     },
+     "execution_count": 243,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df[collective_df['auto']].drop_duplicates(subset=['id','ds','bug','file','image','line']).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
+   "id": "1e2494d8-f6ec-4d13-9203-43e2166401f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(57918, 15)"
+      ]
+     },
+     "execution_count": 244,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.drop_duplicates(subset=['id','ds','file','image','line']).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "4228fceb-b8e8-4ced-b68d-8b48fff6c2a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "user\n",
+       "U3    53037\n",
+       "U1    50880\n",
+       "U2    48898\n",
+       "E2    17791\n",
+       "E3    17200\n",
+       "E1     8147\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df[collective_df['auto']]['user'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 225,
+   "id": "06652b91-16a2-4ad9-9f6b-39a4532d075d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "user\n",
+       "U3    53049\n",
+       "U1    50880\n",
+       "U2    48898\n",
+       "E2    17791\n",
+       "E3    17200\n",
+       "E1     8147\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 225,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df[~collective_df['auto']]['user'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 230,
+   "id": "31cfd0c9-6317-46aa-b6ea-08ace430ac93",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      25987\n",
+       "bug(fix)                  16892\n",
+       "documentation             10308\n",
+       "refactoring                1497\n",
+       "bug(fix) + refactoring      575\n",
+       "test + refactoring          462\n",
+       "other                       230\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 230,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.drop_duplicates(subset=['id','ds','file','image','line'])['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 241,
+   "id": "f04e1a96-3752-4a09-a5bf-c38f8df38a9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.int64(1967)"
+      ]
+     },
+     "execution_count": 241,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.drop_duplicates(subset=['id','ds','file','image','line'])['consensus'].isnull().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "id": "46e92aa6-0ea2-4e09-9594-cab840bf6750",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             27903\n",
+       "bug(fix)         22134\n",
+       "documentation     7881\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 231,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df[collective_df['auto']].drop_duplicates(subset=['id','ds','bug','file','image','line'])['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 232,
+   "id": "9f20ba75-e03c-40a1-ac52-1c8840e6d2f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ds                           bugs-in-py\n",
+       "id               bugs-in-py_PySnooper-1\n",
+       "file              pysnooper/pycompat.py\n",
+       "image                       afterChange\n",
+       "line                                 11\n",
+       "annotation_U1                     other\n",
+       "annotation_U2                       NaN\n",
+       "annotation_U3                  bug(fix)\n",
+       "annotation_E1                  bug(fix)\n",
+       "annotation_E2                       NaN\n",
+       "annotation_E3                       NaN\n",
+       "most_common                    bug(fix)\n",
+       "common_count                          2\n",
+       "n_reviewers                           3\n",
+       "consensus                      bug(fix)\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 232,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.loc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 245,
+   "id": "188e4594-6d83-4555-a9e4-631949c7debd",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds</th>\n",
+       "      <th>id</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation_U1</th>\n",
+       "      <th>annotation_U2</th>\n",
+       "      <th>annotation_U3</th>\n",
+       "      <th>annotation_E1</th>\n",
+       "      <th>annotation_E2</th>\n",
+       "      <th>annotation_E3</th>\n",
+       "      <th>most_common</th>\n",
+       "      <th>common_count</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>consensus</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>99980</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99981</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99982</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99983</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99984</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99985</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99986</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99987</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99988</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99989</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99990</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99991</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99992</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99993</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99994</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99995</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99996</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99997</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99998</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99999</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100000</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100001</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100002</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100003</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100004</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100005</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>100006</th>\n",
+       "      <td>crawl</td>\n",
+       "      <td>crawl_CVE-2021-45116</td>\n",
+       "      <td>tests/template_tests/filter_tests/test_dictsor...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>47</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>test</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           ds                    id  \\\n",
+       "99980   crawl  crawl_CVE-2021-45116   \n",
+       "99981   crawl  crawl_CVE-2021-45116   \n",
+       "99982   crawl  crawl_CVE-2021-45116   \n",
+       "99983   crawl  crawl_CVE-2021-45116   \n",
+       "99984   crawl  crawl_CVE-2021-45116   \n",
+       "99985   crawl  crawl_CVE-2021-45116   \n",
+       "99986   crawl  crawl_CVE-2021-45116   \n",
+       "99987   crawl  crawl_CVE-2021-45116   \n",
+       "99988   crawl  crawl_CVE-2021-45116   \n",
+       "99989   crawl  crawl_CVE-2021-45116   \n",
+       "99990   crawl  crawl_CVE-2021-45116   \n",
+       "99991   crawl  crawl_CVE-2021-45116   \n",
+       "99992   crawl  crawl_CVE-2021-45116   \n",
+       "99993   crawl  crawl_CVE-2021-45116   \n",
+       "99994   crawl  crawl_CVE-2021-45116   \n",
+       "99995   crawl  crawl_CVE-2021-45116   \n",
+       "99996   crawl  crawl_CVE-2021-45116   \n",
+       "99997   crawl  crawl_CVE-2021-45116   \n",
+       "99998   crawl  crawl_CVE-2021-45116   \n",
+       "99999   crawl  crawl_CVE-2021-45116   \n",
+       "100000  crawl  crawl_CVE-2021-45116   \n",
+       "100001  crawl  crawl_CVE-2021-45116   \n",
+       "100002  crawl  crawl_CVE-2021-45116   \n",
+       "100003  crawl  crawl_CVE-2021-45116   \n",
+       "100004  crawl  crawl_CVE-2021-45116   \n",
+       "100005  crawl  crawl_CVE-2021-45116   \n",
+       "100006  crawl  crawl_CVE-2021-45116   \n",
+       "\n",
+       "                                                     file        image  line  \\\n",
+       "99980   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99981   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99982   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99983   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99984   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99985   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99986   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99987   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99988   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99989   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99990   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99991   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99992   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99993   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99994   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99995   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99996   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99997   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99998   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "99999   tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100000  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100001  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100002  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100003  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100004  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100005  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "100006  tests/template_tests/filter_tests/test_dictsor...  afterChange    47   \n",
+       "\n",
+       "       annotation_U1 annotation_U2 annotation_U3 annotation_E1 annotation_E2  \\\n",
+       "99980           test           NaN          test           NaN          test   \n",
+       "99981           test           NaN          test           NaN          test   \n",
+       "99982           test           NaN          test           NaN          test   \n",
+       "99983           test           NaN          test           NaN          test   \n",
+       "99984           test           NaN          test           NaN          test   \n",
+       "99985           test           NaN          test           NaN          test   \n",
+       "99986           test           NaN          test           NaN          test   \n",
+       "99987           test           NaN          test           NaN          test   \n",
+       "99988           test           NaN          test           NaN          test   \n",
+       "99989           test           NaN          test           NaN          test   \n",
+       "99990           test           NaN          test           NaN          test   \n",
+       "99991           test           NaN          test           NaN          test   \n",
+       "99992           test           NaN          test           NaN          test   \n",
+       "99993           test           NaN          test           NaN          test   \n",
+       "99994           test           NaN          test           NaN          test   \n",
+       "99995           test           NaN          test           NaN          test   \n",
+       "99996           test           NaN          test           NaN          test   \n",
+       "99997           test           NaN          test           NaN          test   \n",
+       "99998           test           NaN          test           NaN          test   \n",
+       "99999           test           NaN          test           NaN          test   \n",
+       "100000          test           NaN          test           NaN          test   \n",
+       "100001          test           NaN          test           NaN          test   \n",
+       "100002          test           NaN          test           NaN          test   \n",
+       "100003          test           NaN          test           NaN          test   \n",
+       "100004          test           NaN          test           NaN          test   \n",
+       "100005          test           NaN          test           NaN          test   \n",
+       "100006          test           NaN          test           NaN          test   \n",
+       "\n",
+       "       annotation_E3 most_common  common_count  n_reviewers consensus  \n",
+       "99980            NaN        test             3            3      test  \n",
+       "99981            NaN        test             3            3      test  \n",
+       "99982            NaN        test             3            3      test  \n",
+       "99983            NaN        test             3            3      test  \n",
+       "99984            NaN        test             3            3      test  \n",
+       "99985            NaN        test             3            3      test  \n",
+       "99986            NaN        test             3            3      test  \n",
+       "99987            NaN        test             3            3      test  \n",
+       "99988            NaN        test             3            3      test  \n",
+       "99989            NaN        test             3            3      test  \n",
+       "99990            NaN        test             3            3      test  \n",
+       "99991            NaN        test             3            3      test  \n",
+       "99992            NaN        test             3            3      test  \n",
+       "99993            NaN        test             3            3      test  \n",
+       "99994            NaN        test             3            3      test  \n",
+       "99995            NaN        test             3            3      test  \n",
+       "99996            NaN        test             3            3      test  \n",
+       "99997            NaN        test             3            3      test  \n",
+       "99998            NaN        test             3            3      test  \n",
+       "99999            NaN        test             3            3      test  \n",
+       "100000           NaN        test             3            3      test  \n",
+       "100001           NaN        test             3            3      test  \n",
+       "100002           NaN        test             3            3      test  \n",
+       "100003           NaN        test             3            3      test  \n",
+       "100004           NaN        test             3            3      test  \n",
+       "100005           NaN        test             3            3      test  \n",
+       "100006           NaN        test             3            3      test  "
+      ]
+     },
+     "execution_count": 245,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Trying to find example of duplication (duplicated row)\n",
+    "\n",
+    "i = 100000\n",
+    "G[\n",
+    "    (G['ds'] == G.loc[i]['ds']) & \n",
+    "    (G['id'] == G.loc[i]['id']) &\n",
+    "    (G['file'] == G.loc[i]['file']) &\n",
+    "    (G['image'] == G.loc[i]['image']) &\n",
+    "    (G['line'] == G.loc[i]['line'])\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 248,
+   "id": "7450bf70-26cc-462e-8206-3e8697b116cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(57918, 22)"
+      ]
+     },
+     "execution_count": 248,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto = pd.merge(\n",
+    "    left=collective_df[collective_df['auto']].drop_duplicates(subset=['id','ds','bug','file','image','line']),\n",
+    "    right=G.drop_duplicates(subset=['id','ds','file','image','line']),\n",
+    "    on=['id', 'ds', 'file', 'image', 'line'],\n",
+    "    #how='left',\n",
+    "    how='outer', indicator=\"indicator_column\", suffixes=(\"_auto\", \"_cons\"),\n",
+    ")\n",
+    "collective_df_auto.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 249,
+   "id": "9eea6749-2367-4f97-a172-f9943c10cc11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "indicator_column\n",
+       "both          57918\n",
+       "left_only         0\n",
+       "right_only        0\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 249,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto['indicator_column'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 250,
+   "id": "8b15267c-4b4e-46c1-b2e6-1a1ab5f69a86",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             27903\n",
+       "bug(fix)         22134\n",
+       "documentation     7881\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 250,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08cb9ba0-16b2-48ef-9c13-160f703cf567",
+   "metadata": {},
+   "source": [
+    "Has consensus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 251,
+   "id": "42d6cdd0-7d3e-4c4d-9a79-9c076f6afa18",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             27426\n",
+       "bug(fix)         20699\n",
+       "documentation     7826\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 251,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto[collective_df_auto['consensus'].notnull()]['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 252,
+   "id": "9a659031-e016-43fb-ba87-fcedc8a7503d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             0.982905\n",
+       "bug(fix)         0.935168\n",
+       "documentation    0.993021\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 252,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto[collective_df_auto['consensus'].notnull()]['annotation'].value_counts()/collective_df_auto['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcb19146-430d-46e4-bbba-55a20e0c609c",
+   "metadata": {},
+   "source": [
+    "Agrees with annotation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 253,
+   "id": "0140e598-e0ad-4d42-9b72-7afae1bc33d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             25975\n",
+       "bug(fix)         16666\n",
+       "documentation     7590\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 253,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto[collective_df_auto['consensus'] == collective_df_auto['annotation']]['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 254,
+   "id": "c8b9286e-7bbe-4cac-88a9-648875f59ae5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test             0.930903\n",
+       "bug(fix)         0.752959\n",
+       "documentation    0.963076\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 254,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_auto[collective_df_auto['consensus'] == collective_df_auto['annotation']]['annotation'].value_counts()/collective_df_auto['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d735e3fa-7540-4d86-918a-0a24617eded8",
+   "metadata": {},
+   "source": [
+    "- adds percentage of automated annotations for which there is consensus in manual annotations\n",
+    "\n",
+    "```mermaid\n",
+    "---\n",
+    "config:\n",
+    "  sankey:\n",
+    "    showValues: true\n",
+    "---\n",
+    "sankey-beta\n",
+    "\n",
+    "%% Taken from `notebooks/experiments/00-HaPy_Bug-Paper.ipynb`\n",
+    "%% in https://github.com/ncusi/PatchScope\n",
+    "\n",
+    "%% auto,user,S\n",
+    "A: bug(fix) [75.3%],U: bug(fix),26.403257057366396\n",
+    "A: bug(fix) [75.3%],U: bug(fix) + refactoring,2.2848453633531998\n",
+    "A: bug(fix) [75.3%],U: documentation,3.2967895420989377\n",
+    "A: bug(fix) [75.3%],U: other,0.8265273587913571\n",
+    "A: bug(fix) [75.3%],U: refactoring,3.303166311039168\n",
+    "A: bug(fix) [75.3%],U: test,0.06082456527604052\n",
+    "A: documentation [96.3%],U: bug(fix),0.2972555367522625\n",
+    "A: documentation [96.3%],U: bug(fix) + refactoring,0.006867289627940059\n",
+    "A: documentation [96.3%],U: documentation,14.887793392686335\n",
+    "A: documentation [96.3%],U: other,0.11919652711353101\n",
+    "A: documentation [96.3%],U: refactoring,0.026488117136340226\n",
+    "A: documentation [96.3%],U: test,0.009319893066490078\n",
+    "A: documentation [96.3%],U: test + refactoring,0.004414686189390038\n",
+    "A: test [93.1%],U: bug(fix),0.0941799720403208\n",
+    "A: test [93.1%],U: bug(fix) + refactoring,0.00833885169107007\n",
+    "A: test [93.1%],U: documentation,1.4499791528707724\n",
+    "A: test [93.1%],U: other,0.03924165501680033\n",
+    "A: test [93.1%],U: refactoring,0.8363377725455571\n",
+    "A: test [93.1%],U: test,44.620214357540526\n",
+    "A: test [93.1%],U: test + refactoring,1.4249625977975622\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "15f6cf00-310f-4ece-aa0b-5865245ddf44",
    "metadata": {},
    "source": [

--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -36884,6 +36884,948 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c15cb1c3-3118-4a03-9e0b-574a9ef5184d",
+   "metadata": {},
+   "source": [
+    "First (failed) attempt at computing per-line consensus using **per user entry data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "id": "f46386d3-bf8f-464c-8486-8ef4ac6f15da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ds\n",
+       "crawl         73183\n",
+       "cve           62588\n",
+       "bugs-in-py    60194\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_manual['ds'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "id": "48321b72-cc86-4fcd-a6eb-95f0cb133c60",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['id', 'bundle', 'file', 'fcat', 'image', 'line', 'annotation', 'user',\n",
+       "       'auto', 'ds', 'bug'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 173,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_manual.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "id": "f67c3c86-17f2-4301-9899-2be278a761a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>bundle</th>\n",
+       "      <th>file</th>\n",
+       "      <th>fcat</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>user</th>\n",
+       "      <th>auto</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>bug</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>cve_CVE-2020-10289</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>actionlib_tools/scripts/library.py</td>\n",
+       "      <td>programming</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>103</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>CVE-2020-10289</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   id  bundle                                file  \\\n",
+       "                                                                    \n",
+       "0  cve_CVE-2020-10289  B_6_13  actionlib_tools/scripts/library.py   \n",
+       "\n",
+       "          fcat        image  line annotation user   auto   ds             bug  \n",
+       "                                                                               \n",
+       "0  programming  afterChange   103   bug(fix)   U1  False  cve  CVE-2020-10289  "
+      ]
+     },
+     "execution_count": 175,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_manual.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "id": "540b84a1-64a3-4ac8-a609-7d08f1efb02d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['ds', 'id', 'file', 'image', 'line', 'annotation_U1', 'annotation_U2',\n",
+       "       'annotation_U3', 'annotation_E1', 'annotation_E2', 'annotation_E3',\n",
+       "       'most_common', 'common_count', 'n_reviewers', 'consensus'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 174,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "id": "743cab33-c2b5-4dfd-8127-b80900c12da5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds</th>\n",
+       "      <th>id</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation_U1</th>\n",
+       "      <th>annotation_U2</th>\n",
+       "      <th>annotation_U3</th>\n",
+       "      <th>annotation_E1</th>\n",
+       "      <th>annotation_E2</th>\n",
+       "      <th>annotation_E3</th>\n",
+       "      <th>most_common</th>\n",
+       "      <th>common_count</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>consensus</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bugs-in-py</td>\n",
+       "      <td>bugs-in-py_PySnooper-1</td>\n",
+       "      <td>pysnooper/pycompat.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>11</td>\n",
+       "      <td>other</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           ds                      id                   file        image  \\\n",
+       "0  bugs-in-py  bugs-in-py_PySnooper-1  pysnooper/pycompat.py  afterChange   \n",
+       "\n",
+       "   line annotation_U1 annotation_U2 annotation_U3 annotation_E1 annotation_E2  \\\n",
+       "0    11         other           NaN      bug(fix)      bug(fix)           NaN   \n",
+       "\n",
+       "  annotation_E3 most_common  common_count  n_reviewers consensus  \n",
+       "0           NaN    bug(fix)             2            3  bug(fix)  "
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "id": "5c9b058e-7bf3-4c6c-87c6-845b63ea9101",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "id               object\n",
+       "bundle           object\n",
+       "file             object\n",
+       "fcat             object\n",
+       "image            object\n",
+       "line              int64\n",
+       "annotation       object\n",
+       "user             object\n",
+       "auto               bool\n",
+       "ds               object\n",
+       "bug              object\n",
+       "annotation_U1    object\n",
+       "annotation_U2    object\n",
+       "annotation_U3    object\n",
+       "annotation_E1    object\n",
+       "annotation_E2    object\n",
+       "annotation_E3    object\n",
+       "most_common      object\n",
+       "common_count      int64\n",
+       "n_reviewers       int64\n",
+       "consensus        object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus = pd.merge(\n",
+    "    left=collective_df_manual, right=G,\n",
+    "    on=['id', 'ds', 'file', 'image', 'line'],\n",
+    "    how='left',\n",
+    ")\n",
+    "collective_df_consensus.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "id": "f96e6045-cb11-478e-99de-3898015e8f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "id                               cve_CVE-2020-10289\n",
+       "bundle                                       B_6_13\n",
+       "file             actionlib_tools/scripts/library.py\n",
+       "fcat                                    programming\n",
+       "image                                   afterChange\n",
+       "line                                            103\n",
+       "annotation                                 bug(fix)\n",
+       "user                                             U1\n",
+       "auto                                          False\n",
+       "ds                                              cve\n",
+       "bug                                  CVE-2020-10289\n",
+       "annotation_U1                              bug(fix)\n",
+       "annotation_U2                              bug(fix)\n",
+       "annotation_U3                              bug(fix)\n",
+       "annotation_E1                                   NaN\n",
+       "annotation_E2                                   NaN\n",
+       "annotation_E3                                   NaN\n",
+       "most_common                                bug(fix)\n",
+       "common_count                                      3\n",
+       "n_reviewers                                       3\n",
+       "consensus                                  bug(fix)\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus.loc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "id": "0cdb1314-c80a-4a52-9e94-ae7b09c89a73",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      380909\n",
+       "documentation             300971\n",
+       "bug(fix)                  189213\n",
+       "test + refactoring          7259\n",
+       "refactoring                 4227\n",
+       "bug(fix) + refactoring      2381\n",
+       "other                        689\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "id": "8069b3f1-5805-4bb8-a58c-7bcf6f52a0a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "skipping has test, exists...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "id                                            cve_CVE-2020-10289\n",
+       "bundle                                                    B_6_13\n",
+       "file                          actionlib_tools/scripts/library.py\n",
+       "fcat                                                 programming\n",
+       "image                                                afterChange\n",
+       "line                                                         103\n",
+       "annotation                                              bug(fix)\n",
+       "user                                                          U1\n",
+       "auto                                                       False\n",
+       "ds                                                           cve\n",
+       "bug                                               CVE-2020-10289\n",
+       "annotation_U1                                           bug(fix)\n",
+       "annotation_U2                                           bug(fix)\n",
+       "annotation_U3                                           bug(fix)\n",
+       "annotation_E1                                                NaN\n",
+       "annotation_E2                                                NaN\n",
+       "annotation_E3                                                NaN\n",
+       "most_common                                             bug(fix)\n",
+       "common_count                                                   3\n",
+       "n_reviewers                                                    3\n",
+       "consensus                                               bug(fix)\n",
+       "has test                                                   False\n",
+       "has documentation                                          False\n",
+       "has bug(fix)                                                True\n",
+       "has test + refactoring                                     False\n",
+       "has bug(fix) + refactoring                                 False\n",
+       "has refactoring                                            False\n",
+       "has other                                                  False\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 187,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']:\n",
+    "    col_name = f\"has {col}\"\n",
+    "    if col_name in collective_df_consensus.columns:\n",
+    "        print(f\"skipping {col_name}, exists...\")\n",
+    "        continue\n",
+    "\n",
+    "    collective_df_consensus[col_name] = (\n",
+    "        (collective_df_consensus['annotation_U1'] == col) |\n",
+    "        (collective_df_consensus['annotation_U2'] == col) |\n",
+    "        (collective_df_consensus['annotation_U3'] == col) |\n",
+    "        (collective_df_consensus['annotation_E1'] == col) |\n",
+    "        (collective_df_consensus['annotation_E2'] == col) |\n",
+    "        (collective_df_consensus['annotation_E3'] == col)\n",
+    "    )\n",
+    "\n",
+    "collective_df_consensus.loc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "id": "cbf398b9-996b-4d76-a8a7-28833a3d6cf9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "has test                      399571\n",
+       "has documentation             325183\n",
+       "has bug(fix)                  213486\n",
+       "has test + refactoring         29112\n",
+       "has bug(fix) + refactoring     30659\n",
+       "has refactoring                30895\n",
+       "has other                       6970\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 191,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "has_s = collective_df_consensus[\n",
+    "    [f\"has {col}\" \n",
+    "     for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']\n",
+    "    ]\n",
+    "].sum()\n",
+    "has_s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "id": "74f5db45-7df7-4b9e-a439-ecce7678f17b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "test                      399571\n",
+       "documentation             325183\n",
+       "bug(fix)                  213486\n",
+       "test + refactoring         29112\n",
+       "bug(fix) + refactoring     30659\n",
+       "refactoring                30895\n",
+       "other                       6970\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 193,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "has_s_renamed = has_s.rename({\n",
+    "    f\"has {col}\": col\n",
+    "    for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']\n",
+    "})\n",
+    "has_s_renamed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
+   "id": "dc3aa43c-13ac-4071-a193-dda78a7cd479",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      380909\n",
+       "documentation             300971\n",
+       "bug(fix)                  189213\n",
+       "test + refactoring          7259\n",
+       "refactoring                 4227\n",
+       "bug(fix) + refactoring      2381\n",
+       "other                        689\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 190,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "id": "13dd8c91-8ea9-47ee-b7f6-38c5c59f76b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bug(fix)                  0.886302\n",
+       "bug(fix) + refactoring    0.077661\n",
+       "documentation             0.925543\n",
+       "other                     0.098852\n",
+       "refactoring               0.136818\n",
+       "test                      0.953295\n",
+       "test + refactoring        0.249347\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 194,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['consensus'].value_counts()/has_s_renamed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 196,
+   "id": "20c5c47b-b426-4c64-b041-a2dd827ddaca",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>bundle</th>\n",
+       "      <th>file</th>\n",
+       "      <th>line</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>user</th>\n",
+       "      <th>consensus</th>\n",
+       "      <th>common_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>cve_CVE-2016-10516</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>werkzeug/debug/tbtools.py</td>\n",
+       "      <td>353</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>cve_CVE-2016-10516</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>werkzeug/debug/tbtools.py</td>\n",
+       "      <td>362</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>cve_CVE-2016-10516</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>A_5_20</td>\n",
+       "      <td>werkzeug/debug/tbtools.py</td>\n",
+       "      <td>353</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>E2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>cve_CVE-2016-10516</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>A_5_20</td>\n",
+       "      <td>werkzeug/debug/tbtools.py</td>\n",
+       "      <td>362</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>E2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>cve_CVE-2016-10516</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_3_10</td>\n",
+       "      <td>werkzeug/debug/tbtools.py</td>\n",
+       "      <td>353</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900227</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_5_8</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>364</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900228</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_5_8</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>365</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900229</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_5_8</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>335</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900231</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_5_8</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>357</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900232</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>C_5_8</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>358</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>30659 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        id   ds  bundle  \\\n",
+       "12      cve_CVE-2016-10516  cve  B_6_13   \n",
+       "13      cve_CVE-2016-10516  cve  B_6_13   \n",
+       "15      cve_CVE-2016-10516  cve  A_5_20   \n",
+       "16      cve_CVE-2016-10516  cve  A_5_20   \n",
+       "18      cve_CVE-2016-10516  cve  C_3_10   \n",
+       "...                    ...  ...     ...   \n",
+       "900227  cve_CVE-2018-16876  cve   C_5_8   \n",
+       "900228  cve_CVE-2018-16876  cve   C_5_8   \n",
+       "900229  cve_CVE-2018-16876  cve   C_5_8   \n",
+       "900231  cve_CVE-2018-16876  cve   C_5_8   \n",
+       "900232  cve_CVE-2018-16876  cve   C_5_8   \n",
+       "\n",
+       "                                         file  line              annotation  \\\n",
+       "12                  werkzeug/debug/tbtools.py   353                bug(fix)   \n",
+       "13                  werkzeug/debug/tbtools.py   362                bug(fix)   \n",
+       "15                  werkzeug/debug/tbtools.py   353                bug(fix)   \n",
+       "16                  werkzeug/debug/tbtools.py   362                bug(fix)   \n",
+       "18                  werkzeug/debug/tbtools.py   353  bug(fix) + refactoring   \n",
+       "...                                       ...   ...                     ...   \n",
+       "900227  lib/ansible/plugins/connection/ssh.py   364  bug(fix) + refactoring   \n",
+       "900228  lib/ansible/plugins/connection/ssh.py   365  bug(fix) + refactoring   \n",
+       "900229  lib/ansible/plugins/connection/ssh.py   335                bug(fix)   \n",
+       "900231  lib/ansible/plugins/connection/ssh.py   357                bug(fix)   \n",
+       "900232  lib/ansible/plugins/connection/ssh.py   358                bug(fix)   \n",
+       "\n",
+       "       user               consensus  common_count  \n",
+       "12       U1                bug(fix)             2  \n",
+       "13       U1                bug(fix)             2  \n",
+       "15       E2                bug(fix)             2  \n",
+       "16       E2                bug(fix)             2  \n",
+       "18       U2                bug(fix)             2  \n",
+       "...     ...                     ...           ...  \n",
+       "900227   U2  bug(fix) + refactoring             3  \n",
+       "900228   U2  bug(fix) + refactoring             3  \n",
+       "900229   U2                bug(fix)             2  \n",
+       "900231   U2                bug(fix)             2  \n",
+       "900232   U2                bug(fix)             2  \n",
+       "\n",
+       "[30659 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 196,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']][\n",
+    "    ['id', 'ds', 'bundle', 'file', 'line', 'annotation', 'user', 'consensus', 'common_count']\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "id": "e06205d0-56c6-4ad5-9d81-e4baef774e00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "bug(fix)                  17675\n",
+       "bug(fix) + refactoring    10630\n",
+       "refactoring                1804\n",
+       "documentation               387\n",
+       "other                       142\n",
+       "test + refactoring           15\n",
+       "test                          6\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 201,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']]['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 202,
+   "id": "0dda83d4-6b26-4e66-ae69-77b7ab4fe8fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "bug(fix)                  22374\n",
+       "bug(fix) + refactoring     2381\n",
+       "refactoring                 300\n",
+       "documentation               171\n",
+       "test                          6\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 202,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']]['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 197,
+   "id": "e02df17a-2432-46f6-b8fa-a9df4b9ac5fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      380909\n",
+       "documentation             300971\n",
+       "bug(fix)                  189213\n",
+       "test + refactoring          7259\n",
+       "refactoring                 4227\n",
+       "bug(fix) + refactoring      2381\n",
+       "other                        689\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 197,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 198,
+   "id": "041bb543-0db4-471a-97ae-e6d1c74090ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "test                      378476\n",
+       "documentation             303060\n",
+       "bug(fix)                  179427\n",
+       "refactoring                13113\n",
+       "test + refactoring         12208\n",
+       "bug(fix) + refactoring     11205\n",
+       "other                       2744\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 198,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 200,
+   "id": "d3f20e45-9004-436a-98b5-5f92baa88735",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bug(fix)                  1.054540\n",
+       "bug(fix) + refactoring    0.212494\n",
+       "documentation             0.993107\n",
+       "other                     0.251093\n",
+       "refactoring               0.322352\n",
+       "test                      1.006428\n",
+       "test + refactoring        0.594610\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 200,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['consensus'].value_counts()/collective_df_consensus['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "15f6cf00-310f-4ece-aa0b-5865245ddf44",
    "metadata": {},
    "source": [

--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -36887,7 +36887,7 @@
    "id": "c15cb1c3-3118-4a03-9e0b-574a9ef5184d",
    "metadata": {},
    "source": [
-    "First (failed) attempt at computing per-line consensus using **per user entry data**"
+    "Computing per-line consensus using **per user entry data**"
    ]
   },
   {
@@ -37142,6 +37142,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "634f870c-58f6-4927-ad8f-5fad450f182e",
+   "metadata": {},
+   "source": [
+    "Add the `'consensus'` column to the original per-user/per-annotation data (limited to manual annotations)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 178,
    "id": "5c9b058e-7bf3-4c6c-87c6-845b63ea9101",
@@ -37261,514 +37269,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
-   "id": "8069b3f1-5805-4bb8-a58c-7bcf6f52a0a4",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "skipping has test, exists...\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "id                                            cve_CVE-2020-10289\n",
-       "bundle                                                    B_6_13\n",
-       "file                          actionlib_tools/scripts/library.py\n",
-       "fcat                                                 programming\n",
-       "image                                                afterChange\n",
-       "line                                                         103\n",
-       "annotation                                              bug(fix)\n",
-       "user                                                          U1\n",
-       "auto                                                       False\n",
-       "ds                                                           cve\n",
-       "bug                                               CVE-2020-10289\n",
-       "annotation_U1                                           bug(fix)\n",
-       "annotation_U2                                           bug(fix)\n",
-       "annotation_U3                                           bug(fix)\n",
-       "annotation_E1                                                NaN\n",
-       "annotation_E2                                                NaN\n",
-       "annotation_E3                                                NaN\n",
-       "most_common                                             bug(fix)\n",
-       "common_count                                                   3\n",
-       "n_reviewers                                                    3\n",
-       "consensus                                               bug(fix)\n",
-       "has test                                                   False\n",
-       "has documentation                                          False\n",
-       "has bug(fix)                                                True\n",
-       "has test + refactoring                                     False\n",
-       "has bug(fix) + refactoring                                 False\n",
-       "has refactoring                                            False\n",
-       "has other                                                  False\n",
-       "Name: 0, dtype: object"
-      ]
-     },
-     "execution_count": 187,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']:\n",
-    "    col_name = f\"has {col}\"\n",
-    "    if col_name in collective_df_consensus.columns:\n",
-    "        print(f\"skipping {col_name}, exists...\")\n",
-    "        continue\n",
-    "\n",
-    "    collective_df_consensus[col_name] = (\n",
-    "        (collective_df_consensus['annotation_U1'] == col) |\n",
-    "        (collective_df_consensus['annotation_U2'] == col) |\n",
-    "        (collective_df_consensus['annotation_U3'] == col) |\n",
-    "        (collective_df_consensus['annotation_E1'] == col) |\n",
-    "        (collective_df_consensus['annotation_E2'] == col) |\n",
-    "        (collective_df_consensus['annotation_E3'] == col)\n",
-    "    )\n",
-    "\n",
-    "collective_df_consensus.loc[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 191,
-   "id": "cbf398b9-996b-4d76-a8a7-28833a3d6cf9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "has test                      399571\n",
-       "has documentation             325183\n",
-       "has bug(fix)                  213486\n",
-       "has test + refactoring         29112\n",
-       "has bug(fix) + refactoring     30659\n",
-       "has refactoring                30895\n",
-       "has other                       6970\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 191,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "has_s = collective_df_consensus[\n",
-    "    [f\"has {col}\" \n",
-    "     for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']\n",
-    "    ]\n",
-    "].sum()\n",
-    "has_s"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 193,
-   "id": "74f5db45-7df7-4b9e-a439-ecce7678f17b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "test                      399571\n",
-       "documentation             325183\n",
-       "bug(fix)                  213486\n",
-       "test + refactoring         29112\n",
-       "bug(fix) + refactoring     30659\n",
-       "refactoring                30895\n",
-       "other                       6970\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 193,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "has_s_renamed = has_s.rename({\n",
-    "    f\"has {col}\": col\n",
-    "    for col in ['test', 'documentation', 'bug(fix)', 'test + refactoring', 'bug(fix) + refactoring', 'refactoring', 'other']\n",
-    "})\n",
-    "has_s_renamed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 190,
-   "id": "dc3aa43c-13ac-4071-a193-dda78a7cd479",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "consensus\n",
-       "test                      380909\n",
-       "documentation             300971\n",
-       "bug(fix)                  189213\n",
-       "test + refactoring          7259\n",
-       "refactoring                 4227\n",
-       "bug(fix) + refactoring      2381\n",
-       "other                        689\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 190,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus['consensus'].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 194,
-   "id": "13dd8c91-8ea9-47ee-b7f6-38c5c59f76b9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bug(fix)                  0.886302\n",
-       "bug(fix) + refactoring    0.077661\n",
-       "documentation             0.925543\n",
-       "other                     0.098852\n",
-       "refactoring               0.136818\n",
-       "test                      0.953295\n",
-       "test + refactoring        0.249347\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 194,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus['consensus'].value_counts()/has_s_renamed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 196,
-   "id": "20c5c47b-b426-4c64-b041-a2dd827ddaca",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>ds</th>\n",
-       "      <th>bundle</th>\n",
-       "      <th>file</th>\n",
-       "      <th>line</th>\n",
-       "      <th>annotation</th>\n",
-       "      <th>user</th>\n",
-       "      <th>consensus</th>\n",
-       "      <th>common_count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>cve_CVE-2016-10516</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>B_6_13</td>\n",
-       "      <td>werkzeug/debug/tbtools.py</td>\n",
-       "      <td>353</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>cve_CVE-2016-10516</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>B_6_13</td>\n",
-       "      <td>werkzeug/debug/tbtools.py</td>\n",
-       "      <td>362</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>cve_CVE-2016-10516</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>A_5_20</td>\n",
-       "      <td>werkzeug/debug/tbtools.py</td>\n",
-       "      <td>353</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>E2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>cve_CVE-2016-10516</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>A_5_20</td>\n",
-       "      <td>werkzeug/debug/tbtools.py</td>\n",
-       "      <td>362</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>E2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>cve_CVE-2016-10516</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_3_10</td>\n",
-       "      <td>werkzeug/debug/tbtools.py</td>\n",
-       "      <td>353</td>\n",
-       "      <td>bug(fix) + refactoring</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>900227</th>\n",
-       "      <td>cve_CVE-2018-16876</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
-       "      <td>364</td>\n",
-       "      <td>bug(fix) + refactoring</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix) + refactoring</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>900228</th>\n",
-       "      <td>cve_CVE-2018-16876</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
-       "      <td>365</td>\n",
-       "      <td>bug(fix) + refactoring</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix) + refactoring</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>900229</th>\n",
-       "      <td>cve_CVE-2018-16876</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
-       "      <td>335</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>900231</th>\n",
-       "      <td>cve_CVE-2018-16876</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
-       "      <td>357</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>900232</th>\n",
-       "      <td>cve_CVE-2018-16876</td>\n",
-       "      <td>cve</td>\n",
-       "      <td>C_5_8</td>\n",
-       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
-       "      <td>358</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>30659 rows × 9 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                        id   ds  bundle  \\\n",
-       "12      cve_CVE-2016-10516  cve  B_6_13   \n",
-       "13      cve_CVE-2016-10516  cve  B_6_13   \n",
-       "15      cve_CVE-2016-10516  cve  A_5_20   \n",
-       "16      cve_CVE-2016-10516  cve  A_5_20   \n",
-       "18      cve_CVE-2016-10516  cve  C_3_10   \n",
-       "...                    ...  ...     ...   \n",
-       "900227  cve_CVE-2018-16876  cve   C_5_8   \n",
-       "900228  cve_CVE-2018-16876  cve   C_5_8   \n",
-       "900229  cve_CVE-2018-16876  cve   C_5_8   \n",
-       "900231  cve_CVE-2018-16876  cve   C_5_8   \n",
-       "900232  cve_CVE-2018-16876  cve   C_5_8   \n",
-       "\n",
-       "                                         file  line              annotation  \\\n",
-       "12                  werkzeug/debug/tbtools.py   353                bug(fix)   \n",
-       "13                  werkzeug/debug/tbtools.py   362                bug(fix)   \n",
-       "15                  werkzeug/debug/tbtools.py   353                bug(fix)   \n",
-       "16                  werkzeug/debug/tbtools.py   362                bug(fix)   \n",
-       "18                  werkzeug/debug/tbtools.py   353  bug(fix) + refactoring   \n",
-       "...                                       ...   ...                     ...   \n",
-       "900227  lib/ansible/plugins/connection/ssh.py   364  bug(fix) + refactoring   \n",
-       "900228  lib/ansible/plugins/connection/ssh.py   365  bug(fix) + refactoring   \n",
-       "900229  lib/ansible/plugins/connection/ssh.py   335                bug(fix)   \n",
-       "900231  lib/ansible/plugins/connection/ssh.py   357                bug(fix)   \n",
-       "900232  lib/ansible/plugins/connection/ssh.py   358                bug(fix)   \n",
-       "\n",
-       "       user               consensus  common_count  \n",
-       "12       U1                bug(fix)             2  \n",
-       "13       U1                bug(fix)             2  \n",
-       "15       E2                bug(fix)             2  \n",
-       "16       E2                bug(fix)             2  \n",
-       "18       U2                bug(fix)             2  \n",
-       "...     ...                     ...           ...  \n",
-       "900227   U2  bug(fix) + refactoring             3  \n",
-       "900228   U2  bug(fix) + refactoring             3  \n",
-       "900229   U2                bug(fix)             2  \n",
-       "900231   U2                bug(fix)             2  \n",
-       "900232   U2                bug(fix)             2  \n",
-       "\n",
-       "[30659 rows x 9 columns]"
-      ]
-     },
-     "execution_count": 196,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']][\n",
-    "    ['id', 'ds', 'bundle', 'file', 'line', 'annotation', 'user', 'consensus', 'common_count']\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 201,
-   "id": "e06205d0-56c6-4ad5-9d81-e4baef774e00",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "annotation\n",
-       "bug(fix)                  17675\n",
-       "bug(fix) + refactoring    10630\n",
-       "refactoring                1804\n",
-       "documentation               387\n",
-       "other                       142\n",
-       "test + refactoring           15\n",
-       "test                          6\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 201,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']]['annotation'].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 202,
-   "id": "0dda83d4-6b26-4e66-ae69-77b7ab4fe8fb",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "consensus\n",
-       "bug(fix)                  22374\n",
-       "bug(fix) + refactoring     2381\n",
-       "refactoring                 300\n",
-       "documentation               171\n",
-       "test                          6\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 202,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus[collective_df_consensus['has bug(fix) + refactoring']]['consensus'].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 197,
-   "id": "e02df17a-2432-46f6-b8fa-a9df4b9ac5fe",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "consensus\n",
-       "test                      380909\n",
-       "documentation             300971\n",
-       "bug(fix)                  189213\n",
-       "test + refactoring          7259\n",
-       "refactoring                 4227\n",
-       "bug(fix) + refactoring      2381\n",
-       "other                        689\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 197,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "collective_df_consensus['consensus'].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 198,
    "id": "041bb543-0db4-471a-97ae-e6d1c74090ef",
    "metadata": {},
@@ -37798,30 +37298,368 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 203,
    "id": "d3f20e45-9004-436a-98b5-5f92baa88735",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "bug(fix)                  1.054540\n",
-       "bug(fix) + refactoring    0.212494\n",
-       "documentation             0.993107\n",
-       "other                     0.251093\n",
-       "refactoring               0.322352\n",
-       "test                      1.006428\n",
-       "test + refactoring        0.594610\n",
-       "Name: count, dtype: float64"
+       "annotation == consensus\n",
+       "True     834712\n",
+       "False     65521\n",
+       "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 200,
+     "execution_count": 203,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "collective_df_consensus['consensus'].value_counts()/collective_df_consensus['annotation'].value_counts()"
+    "collective_df_consensus['annotation == consensus'] = collective_df_consensus['annotation'] == collective_df_consensus['consensus']\n",
+    "collective_df_consensus['annotation == consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
+   "id": "0d0d3984-cb92-4db1-a599-9b6720a991cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation == consensus\n",
+       "True     0.927218\n",
+       "False    0.072782\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 204,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus['annotation == consensus'].value_counts()/collective_df_consensus.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "id": "7c17f48e-18db-45f0-aba0-77a963dcd128",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "bug(fix)                  166911\n",
+       "bug(fix) + refactoring      1585\n",
+       "documentation             288657\n",
+       "other                        491\n",
+       "refactoring                 3541\n",
+       "test                      368774\n",
+       "test + refactoring          4753\n",
+       "Name: annotation == consensus, dtype: int64"
+      ]
+     },
+     "execution_count": 205,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[['annotation', 'consensus', 'annotation == consensus']].groupby('annotation')['annotation == consensus'].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "id": "ca3c2035-86fa-4dac-93c9-381df4d20883",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "annotation\n",
+       "bug(fix)                  0.930245\n",
+       "bug(fix) + refactoring    0.141455\n",
+       "documentation             0.952475\n",
+       "other                     0.178936\n",
+       "refactoring               0.270037\n",
+       "test                      0.974366\n",
+       "test + refactoring        0.389335\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 206,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[['annotation', 'consensus', 'annotation == consensus']]\\\n",
+    "    .groupby('annotation')['annotation == consensus'].sum()\\\n",
+    "/collective_df_consensus['annotation'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "id": "37b63cc2-0512-48b7-9a70-c8c89bb48c80",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>ds</th>\n",
+       "      <th>file</th>\n",
+       "      <th>image</th>\n",
+       "      <th>line</th>\n",
+       "      <th>bundle</th>\n",
+       "      <th>user</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>n_reviewers</th>\n",
+       "      <th>consensus</th>\n",
+       "      <th>annotation == consensus</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>128</th>\n",
+       "      <td>cve_CVE-2022-24859</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>PyPDF2/pdf.py</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>2824</td>\n",
+       "      <td>A_3_22</td>\n",
+       "      <td>E3</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1175</th>\n",
+       "      <td>cve_CVE-2018-1000117</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Modules/posixmodule.c</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>7474</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1186</th>\n",
+       "      <td>cve_CVE-2018-1000117</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Modules/posixmodule.c</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>7513</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1187</th>\n",
+       "      <td>cve_CVE-2018-1000117</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Modules/posixmodule.c</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>7514</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1205</th>\n",
+       "      <td>cve_CVE-2018-1000117</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Modules/posixmodule.c</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>7611</td>\n",
+       "      <td>B_6_13</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>891798</th>\n",
+       "      <td>cve_CVE-2019-10160</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Lib/urlparse.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>184</td>\n",
+       "      <td>C_1_12</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix) + refactoring</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>891803</th>\n",
+       "      <td>cve_CVE-2019-10160</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Lib/urlparse.py</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>183</td>\n",
+       "      <td>C_1_12</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>891804</th>\n",
+       "      <td>cve_CVE-2019-10160</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>Lib/urlparse.py</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>184</td>\n",
+       "      <td>C_1_12</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900188</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>342</td>\n",
+       "      <td>B_3_16</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>900196</th>\n",
+       "      <td>cve_CVE-2018-16876</td>\n",
+       "      <td>cve</td>\n",
+       "      <td>lib/ansible/plugins/connection/ssh.py</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>339</td>\n",
+       "      <td>B_3_16</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>other</td>\n",
+       "      <td>3</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2253 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          id   ds                                   file  \\\n",
+       "128       cve_CVE-2022-24859  cve                          PyPDF2/pdf.py   \n",
+       "1175    cve_CVE-2018-1000117  cve                  Modules/posixmodule.c   \n",
+       "1186    cve_CVE-2018-1000117  cve                  Modules/posixmodule.c   \n",
+       "1187    cve_CVE-2018-1000117  cve                  Modules/posixmodule.c   \n",
+       "1205    cve_CVE-2018-1000117  cve                  Modules/posixmodule.c   \n",
+       "...                      ...  ...                                    ...   \n",
+       "891798    cve_CVE-2019-10160  cve                        Lib/urlparse.py   \n",
+       "891803    cve_CVE-2019-10160  cve                        Lib/urlparse.py   \n",
+       "891804    cve_CVE-2019-10160  cve                        Lib/urlparse.py   \n",
+       "900188    cve_CVE-2018-16876  cve  lib/ansible/plugins/connection/ssh.py   \n",
+       "900196    cve_CVE-2018-16876  cve  lib/ansible/plugins/connection/ssh.py   \n",
+       "\n",
+       "               image  line  bundle user annotation  n_reviewers  \\\n",
+       "128     beforeChange  2824  A_3_22   E3      other            3   \n",
+       "1175     afterChange  7474  B_6_13   U1      other            3   \n",
+       "1186     afterChange  7513  B_6_13   U1      other            3   \n",
+       "1187     afterChange  7514  B_6_13   U1      other            3   \n",
+       "1205     afterChange  7611  B_6_13   U1      other            3   \n",
+       "...              ...   ...     ...  ...        ...          ...   \n",
+       "891798   afterChange   184  C_1_12   U2      other            3   \n",
+       "891803  beforeChange   183  C_1_12   U2      other            3   \n",
+       "891804  beforeChange   184  C_1_12   U2      other            3   \n",
+       "900188   afterChange   342  B_3_16   U1      other            3   \n",
+       "900196  beforeChange   339  B_3_16   U1      other            3   \n",
+       "\n",
+       "                     consensus  annotation == consensus  \n",
+       "128                   bug(fix)                    False  \n",
+       "1175                  bug(fix)                    False  \n",
+       "1186                       NaN                    False  \n",
+       "1187                  bug(fix)                    False  \n",
+       "1205                  bug(fix)                    False  \n",
+       "...                        ...                      ...  \n",
+       "891798  bug(fix) + refactoring                    False  \n",
+       "891803                     NaN                    False  \n",
+       "891804                     NaN                    False  \n",
+       "900188                     NaN                    False  \n",
+       "900196                bug(fix)                    False  \n",
+       "\n",
+       "[2253 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 214,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collective_df_consensus[\n",
+    "    (collective_df_consensus['annotation'] == 'other') &\n",
+    "    (~collective_df_consensus['annotation == consensus'])\n",
+    "][\n",
+    "    ['id','ds','file','image','line','bundle','user','annotation','n_reviewers','consensus','annotation == consensus']\n",
+    "]"
    ]
   },
   {

--- a/notebooks/experiments/01-compare_annotations.ipynb
+++ b/notebooks/experiments/01-compare_annotations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "376dce27-af8c-417f-b87f-8bfbc274a48f",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "b56ec732-ef0a-46da-a0ca-2fe4391b31fe",
    "metadata": {},
    "outputs": [],
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "d60c1747-dddb-4750-acb1-9c06d7b6ee04",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "511cfc9f-38bd-4d4f-946f-b7b9951ae315",
    "metadata": {},
    "outputs": [
@@ -124,7 +124,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "b98f154b-2041-41f8-bd1d-fe5e441033cd",
    "metadata": {},
    "outputs": [
@@ -145,7 +145,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "7e30759a-5d68-4019-90e5-8b4ecf8099ac",
    "metadata": {},
    "outputs": [],
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "4c04cbe0-1705-4bd7-a7b1-0abeb92585ec",
    "metadata": {},
    "outputs": [],
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "ea5a4918-5514-4f08-af47-dcb8b39dc4bd",
    "metadata": {},
    "outputs": [
@@ -187,7 +187,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "9cd66d15-ace2-4355-b066-dec59e08360c",
    "metadata": {
     "scrolled": true
@@ -253,7 +253,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "96d3dcbd-aaec-44d8-9e4c-5076eb648e92",
    "metadata": {},
    "outputs": [
@@ -278,7 +278,7 @@
        " '-': [{'id': 85, 'type': 'bug(fix)'}]}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "f4192f0d-d1ac-4afe-969f-89bc30e7af6b",
    "metadata": {},
    "outputs": [
@@ -313,7 +313,7 @@
        " '-': []}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "8535cd0f-9f39-4cfd-bb9a-23fdf6c38c3a",
    "metadata": {
     "scrolled": true
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "6177b8fb-0cdc-4942-97a0-6630d62d9ae1",
    "metadata": {},
    "outputs": [],
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "37f19b94-1360-4087-896c-d0f6c632e216",
    "metadata": {},
    "outputs": [
@@ -409,7 +409,7 @@
        "{'rA': 1, 'rB': 1, 'rC': 0, 'rD': 1, 'pA': 2, 'pB': 4, 'pC': 1, 'pD': 3}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "8a80ab8f-dd45-41ae-8e2d-d3ab2d4a6213",
    "metadata": {},
    "outputs": [],
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "1a53474e-d9bb-4837-a39c-7c5c5226f021",
    "metadata": {},
    "outputs": [],
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "f1daa15c-c1b3-45a5-aa8a-3028023e33aa",
    "metadata": {
     "scrolled": true
@@ -11106,7 +11106,7 @@
        "      'beforeChange': []}}]]}]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11125,7 +11125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "b0c7cc98-3545-4bd6-8385-9d5ab92b70ee",
    "metadata": {},
    "outputs": [
@@ -11143,7 +11143,7 @@
        " PosixPath('../../data/experiments/HaPy-Bug/cve_blame.csv')]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11155,7 +11155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "08bf7d0f-d85b-4340-96de-f3fde67f31e2",
    "metadata": {},
    "outputs": [
@@ -11163,16 +11163,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total 81736\n",
-      "-rw-r--r-- 1 jnareb jnareb  2558150 Dec  1 01:30 bip_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb 50424028 Dec  1 01:30 collective.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb 18222220 Dec  1 01:30 consensus.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb  6895847 Dec  1 01:30 crawl_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb  5385717 Dec  1 01:30 cve_blame.csv\n",
-      "-rw-r--r-- 1 jnareb jnareb      939 Dec  1 01:30 hapybug_line_callback_func.py\n",
-      "-rw-r--r-- 1 jnareb jnareb    15132 Dec  1 01:30 repositories.json\n",
-      "-rwxr-xr-x 1 jnareb jnareb    26627 Dec  1 01:30 \u001b[0m\u001b[01;32mrun_annotation_bugsinpy_repos.sh\u001b[0m*\n",
-      "-rwxr-xr-x 1 jnareb jnareb   150891 Dec  1 01:30 \u001b[01;32mrun_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "total 81732\n",
+      "-rw-r--r-- 1 jnareb jnareb  2558150 Dec 13 20:03 bip_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb 50424028 Dec 13 20:03 collective.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb 18222220 Dec 13 20:03 consensus.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb  6895847 Dec 13 20:03 crawl_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb  5385717 Dec 13 20:03 cve_blame.csv\n",
+      "-rw-r--r-- 1 jnareb jnareb      939 Dec 13 20:03 hapybug_line_callback_func.py\n",
+      "-rw-r--r-- 1 jnareb jnareb    15132 Dec 13 20:03 repositories.json\n",
+      "-rwxr-xr-x 1 jnareb jnareb    26627 Dec 13 20:03 \u001b[0m\u001b[01;32mrun_annotation_bugsinpy_repos.sh\u001b[0m*\n",
+      "-rwxr-xr-x 1 jnareb jnareb   150891 Dec 13 20:03 \u001b[01;32mrun_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -11182,7 +11182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "0058312b-27c4-465b-b67f-ccbaac7602dc",
    "metadata": {},
    "outputs": [
@@ -11192,7 +11192,7 @@
        "PosixPath('../../data/experiments/HaPy-Bug/collective.csv')"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11204,7 +11204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "c3efef45-8da3-4b42-99df-6b7c80e88d02",
    "metadata": {},
    "outputs": [
@@ -11462,7 +11462,7 @@
        "[391918 rows x 11 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11475,7 +11475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "9ffdc348-5788-4d32-9616-6ffdfd32b86e",
    "metadata": {},
    "outputs": [
@@ -11489,7 +11489,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11500,7 +11500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "c80eb300-885a-48b6-b8b3-cbc9db3a6009",
    "metadata": {},
    "outputs": [
@@ -11514,7 +11514,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11526,7 +11526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "306a655e-b58a-401d-b311-8ba0f078d416",
    "metadata": {},
    "outputs": [
@@ -11548,7 +11548,7 @@
        "Name: id, Length: 496, dtype: object"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11559,7 +11559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "e525e93d-8f11-43d4-8be7-ea13de7d82be",
    "metadata": {},
    "outputs": [
@@ -11569,7 +11569,7 @@
        "(496,)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11617,7 +11617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "6efdb59c-6692-4386-95fc-729188f276da",
    "metadata": {},
    "outputs": [],
@@ -11627,7 +11627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "f21d9a51-5f22-4dfb-939e-b1a00a031ef2",
    "metadata": {
     "scrolled": true
@@ -11746,7 +11746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "a4d047c6-6021-4d8a-8c43-d89e4ec0c9a9",
    "metadata": {},
    "outputs": [
@@ -11764,7 +11764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "id": "ea24fca3-7799-4906-ae98-405a875009d5",
    "metadata": {},
    "outputs": [
@@ -11774,7 +11774,7 @@
        "PosixPath('/mnt/data/python-diff-annotator/example_annotations/HaPy-Bug/bugsinpy-dataset/cookiecutter-1/annotation/7f6804c4953a18386809f11faf4d86898570debc.v2.json')"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11789,7 +11789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "id": "ff3e8c8e-435b-40ed-8e73-4bda1cbc85d9",
    "metadata": {},
    "outputs": [
@@ -11799,7 +11799,7 @@
        "dict"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11813,7 +11813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "id": "94f4ced7-0846-4055-a715-31f5102ac3c0",
    "metadata": {},
    "outputs": [
@@ -11823,7 +11823,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11834,7 +11834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "id": "40633644-7a46-415c-baa4-f570f81dd28e",
    "metadata": {},
    "outputs": [
@@ -11844,7 +11844,7 @@
        "{'id': '7f6804c4953a18386809f11faf4d86898570debc'}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11855,7 +11855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "id": "78053ed0-e6d6-4ac4-a31b-607c549331e6",
    "metadata": {},
    "outputs": [
@@ -11876,7 +11876,7 @@
        " 'n_add': 14}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11887,7 +11887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "id": "c4dcf143-0652-4fdb-8864-b23f5809fc56",
    "metadata": {},
    "outputs": [
@@ -11897,7 +11897,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11908,7 +11908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "id": "6656a404-ffc0-462a-9b61-a7af3c50275b",
    "metadata": {
     "scrolled": true
@@ -11963,7 +11963,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11998,7 +11998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "id": "d09aa5d4-5887-4d3e-8202-04aec95d6da5",
    "metadata": {},
    "outputs": [
@@ -12008,7 +12008,7 @@
        "True"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12020,7 +12020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "id": "ce20ae51-c5b0-4314-9b8c-6f88856a5bd1",
    "metadata": {},
    "outputs": [
@@ -12062,7 +12062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "id": "1308ac24-045a-4d8c-a711-b599e6862c64",
    "metadata": {},
    "outputs": [],
@@ -12072,7 +12072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "id": "665af095-2dc3-49c5-a0dc-bd7efd3dc782",
    "metadata": {},
    "outputs": [
@@ -12089,7 +12089,7 @@
        "  'cookiecutter-4']}"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12115,7 +12115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "id": "489b0f11-5954-4dfc-8560-39d97c0777b4",
    "metadata": {},
    "outputs": [
@@ -12125,7 +12125,7 @@
        "dict_keys(['pandas', 'thefuck', 'tornado', 'black', 'youtube-dl', 'spacy', 'keras', 'ansible', 'scrapy', 'fastapi', 'luigi', 'matplotlib', 'tqdm', 'sanic', 'cookiecutter', 'httpie', 'PySnooper'])"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12144,7 +12144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "id": "aa8d5632-c6d2-4fdb-97b0-b450e3cd7a3d",
    "metadata": {},
    "outputs": [
@@ -12152,7 +12152,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 jnareb jnareb 15132 Dec  1 01:30 ../../data/experiments/HaPy-Bug/repositories.json\n"
+      "-rw-r--r-- 1 jnareb jnareb 15132 Dec 13 20:03 ../../data/experiments/HaPy-Bug/repositories.json\n"
      ]
     }
    ],
@@ -12163,7 +12163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "id": "8cadb7e1-87d1-4e3c-9774-874cea0e5a02",
    "metadata": {},
    "outputs": [
@@ -12181,7 +12181,7 @@
        "  'repository_path': '/mnt/data/python_bug_localization_data/repositories/black'}]"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12195,7 +12195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "id": "5574e2ee-4653-46d3-877e-7543f3ddb663",
    "metadata": {},
    "outputs": [
@@ -12206,7 +12206,7 @@
        " 'path': '/mnt/data/python_bug_localization_data/repositories/cookiecutter'}"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12230,7 +12230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "id": "8a4ad948-3eb9-407c-9771-24022314d20d",
    "metadata": {},
    "outputs": [],
@@ -12240,7 +12240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "id": "a442f585-17a9-4e72-ac16-311f3b2d5521",
    "metadata": {
     "scrolled": true
@@ -12267,7 +12267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "id": "16eb6420-8f9f-498f-b907-310a84144a51",
    "metadata": {
     "scrolled": true
@@ -12417,7 +12417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "id": "ef6f6d45-8b96-4ccf-9f99-0f117f3eb2ee",
    "metadata": {},
    "outputs": [],
@@ -12428,7 +12428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "id": "0cee0e4c-faf1-43ec-a5d1-71babf93be4d",
    "metadata": {},
    "outputs": [
@@ -12464,7 +12464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "id": "3a6beef5-c325-4e92-9a18-60e4cc314339",
    "metadata": {},
    "outputs": [
@@ -12485,7 +12485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "id": "51cf8b16-4a5b-43d5-a886-18aa5f7fdf90",
    "metadata": {},
    "outputs": [
@@ -12495,7 +12495,7 @@
        "PosixPath('/mnt/data/python-diff-annotator/example_annotations/bugsinpy-from-repo/cookiecutter/7f6804c4953a18386809f11faf4d86898570debc.v2.json')"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12507,7 +12507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "id": "3204ff1a-c4ad-4684-976d-d6fd041be709",
    "metadata": {},
    "outputs": [
@@ -12517,7 +12517,7 @@
        "dict"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12531,7 +12531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 52,
    "id": "934cffd9-473e-4e37-a90b-823cd8cc5b20",
    "metadata": {},
    "outputs": [
@@ -12541,7 +12541,7 @@
        "dict_keys(['commit_metadata', 'changes', 'diff_metadata'])"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12560,7 +12560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 53,
    "id": "0e9e1736-5d31-4ac0-bb25-8fd4182ea815",
    "metadata": {},
    "outputs": [
@@ -12583,7 +12583,7 @@
        " 'message': 'Fix default values being loaded with wrong encoding on Windows (#1414)\\n\\nExplicitly set the encoding to utf-8 when reading the context file to\\nensure values are correctly loaded.\\n\\nCo-authored-by: Andrey Shpak <insspb@users.noreply.github.com>\\n'}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12594,7 +12594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 54,
    "id": "9eb4e022-ece7-4af6-9164-55fbe5bd73ea",
    "metadata": {},
    "outputs": [
@@ -12615,7 +12615,7 @@
        " 'n_add': 14}"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12626,7 +12626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 55,
    "id": "56640641-921c-4930-bf83-8cf9bf2e88ba",
    "metadata": {},
    "outputs": [
@@ -12636,7 +12636,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12647,7 +12647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 56,
    "id": "7a044ee7-ee05-4832-9a53-9f49cbb21ebb",
    "metadata": {
     "scrolled": true
@@ -12702,7 +12702,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12721,7 +12721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 57,
    "id": "c0eed77f-d269-4983-8288-4c0e8d97e085",
    "metadata": {},
    "outputs": [],
@@ -12731,7 +12731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 58,
    "id": "589885ec-e18f-408c-84ba-b8f9a4753905",
    "metadata": {},
    "outputs": [
@@ -12739,7 +12739,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rwxr-xr-x 1 jnareb jnareb 429 Nov 30 20:12 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "-rwxr-xr-x 1 jnareb jnareb 429 Dec  5 09:35 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -12749,7 +12749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 59,
    "id": "66e2acc9-66c7-42b0-a622-51116874f77e",
    "metadata": {},
    "outputs": [],
@@ -12759,7 +12759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 60,
    "id": "a1ce811e-dc1c-4592-b764-6996f3a3a314",
    "metadata": {},
    "outputs": [],
@@ -12769,7 +12769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 61,
    "id": "5e2faf0a-de56-40be-b159-fa2e8ec2fbbf",
    "metadata": {},
    "outputs": [],
@@ -12794,7 +12794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 62,
    "id": "1acd39f7-7db6-4f36-b214-b27eeb6496e3",
    "metadata": {},
    "outputs": [
@@ -12802,7 +12802,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 jnareb jnareb 939 Dec  1 01:30 ../../data/experiments/HaPy-Bug/hapybug_line_callback_func.py\n"
+      "-rw-r--r-- 1 jnareb jnareb 939 Dec 13 20:03 ../../data/experiments/HaPy-Bug/hapybug_line_callback_func.py\n"
      ]
     }
    ],
@@ -12812,7 +12812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 63,
    "id": "24ad4929-7aad-40b2-830b-9b22ca324ef4",
    "metadata": {},
    "outputs": [
@@ -12859,7 +12859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 64,
    "id": "4ae741f5-b470-4bf6-b203-afa236316f49",
    "metadata": {},
    "outputs": [
@@ -12867,7 +12867,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rwxr-xr-x 1 jnareb jnareb 429 Dec  5 09:35 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
+      "-rwxr-xr-x 1 jnareb jnareb 429 Jan 28 09:57 \u001b[0m\u001b[01;32m../../run_annotation_hapy_bip_repos.sh\u001b[0m*\n"
      ]
     }
    ],
@@ -12885,7 +12885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 65,
    "id": "776ce2ef-9c90-480d-a346-6a92706c1960",
    "metadata": {},
    "outputs": [
@@ -12897,7 +12897,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12908,7 +12908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 66,
    "id": "2d9039fb-08c3-4316-9a17-5f2fe05a35a3",
    "metadata": {},
    "outputs": [
@@ -12929,7 +12929,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12940,7 +12940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 67,
    "id": "45d5c707-d3a8-41c2-bafa-ca446d783b2c",
    "metadata": {},
    "outputs": [
@@ -13085,7 +13085,7 @@
        "4  programming   afterChange   103   bug(fix)   U2  False  cve  CVE-2020-10289  "
       ]
      },
-     "execution_count": 68,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13096,7 +13096,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 68,
    "id": "f92d0c71-80ef-4b81-8002-60728afed203",
    "metadata": {},
    "outputs": [
@@ -13110,7 +13110,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13121,7 +13121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 69,
    "id": "a2a00259-07f6-4249-9185-9a313ff5dbd4",
    "metadata": {},
    "outputs": [
@@ -13379,7 +13379,7 @@
        "[60194 rows x 11 columns]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13391,7 +13391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 70,
    "id": "3612172f-5aa6-450b-bba3-69a3f40f055d",
    "metadata": {},
    "outputs": [
@@ -13405,7 +13405,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13416,7 +13416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 71,
    "id": "639ae27a-fe99-4ecb-9ba8-fd22ac6bc948",
    "metadata": {},
    "outputs": [
@@ -13756,7 +13756,7 @@
        "145624   121           test   U3  False  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 72,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13772,7 +13772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 72,
    "id": "26469e00-6729-4f5e-8249-df739ee917f9",
    "metadata": {},
    "outputs": [
@@ -13782,7 +13782,7 @@
        "dict_keys(['cookiecutter/generate.py', '/dev/null', 'tests/test-generate-context/non_ascii.json', 'tests/test_generate_context.py'])"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13793,7 +13793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 73,
    "id": "dec16177-c463-46ca-82dc-ad1c2ba560a3",
    "metadata": {
     "scrolled": true
@@ -13848,7 +13848,7 @@
        "    [105, ['Text', 'Whitespace'], '\\n']]}]}"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13859,7 +13859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 74,
    "id": "988fd36f-282e-4084-a778-61e956c9c001",
    "metadata": {
     "scrolled": true
@@ -13910,7 +13910,7 @@
        "  'bug': 'cookiecutter-1'}]"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13945,7 +13945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 75,
    "id": "f8d8fe49-7550-4184-afbc-cedd8f4eae51",
    "metadata": {},
    "outputs": [
@@ -14199,7 +14199,7 @@
        "15         test   afterChange   121       test  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 76,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14211,7 +14211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 76,
    "id": "9a4f56eb-b88a-4f60-8e5b-a2c55151a450",
    "metadata": {},
    "outputs": [
@@ -14322,7 +14322,7 @@
        "4         test   afterChange     3       test  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 77,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14333,7 +14333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 77,
    "id": "f21eea10-bce7-4b9c-a3d5-90d07b7ac3e8",
    "metadata": {},
    "outputs": [
@@ -14486,7 +14486,7 @@
        "145613     3       test   U3  False  bugs-in-py  cookiecutter-1  "
       ]
      },
-     "execution_count": 78,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14505,7 +14505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 78,
    "id": "063cda3e-5fb4-41c4-8c42-0acc689d95b2",
    "metadata": {},
    "outputs": [
@@ -14644,7 +14644,7 @@
        "145613     3       test  "
       ]
      },
-     "execution_count": 79,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14656,7 +14656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 79,
    "id": "55027f0f-5653-4b23-b419-e644556f3dfb",
    "metadata": {},
    "outputs": [
@@ -14755,7 +14755,7 @@
        "4   afterChange     3       test  "
       ]
      },
-     "execution_count": 80,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14767,7 +14767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 80,
    "id": "40985c6c-ff03-4b36-8ea5-0e4d11c1ff18",
    "metadata": {},
    "outputs": [
@@ -14909,7 +14909,7 @@
        "4     3            test         test            test             both  "
       ]
      },
-     "execution_count": 81,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14925,7 +14925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 81,
    "id": "3ff9be8a-3e4b-423b-abf9-98378a1a6e65",
    "metadata": {},
    "outputs": [
@@ -15086,7 +15086,7 @@
        "4     True           True  "
       ]
      },
-     "execution_count": 82,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15100,7 +15100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 82,
    "id": "0b7ac5e8-dc4c-4c03-9eaf-b1b261742bfb",
    "metadata": {},
    "outputs": [
@@ -15113,7 +15113,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15124,7 +15124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 83,
    "id": "c6c193aa-8714-4b0c-81fd-e03690dc0fcb",
    "metadata": {},
    "outputs": [
@@ -15198,7 +15198,7 @@
        "6             both     True          False  "
       ]
      },
-     "execution_count": 84,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15217,7 +15217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 84,
    "id": "aa73bbae-279a-44d2-ab36-dbc24aa51de1",
    "metadata": {},
    "outputs": [
@@ -15230,7 +15230,7 @@
        " '457a1a4e862aab4102b644ff1d2b2e2b5a766b3c': 'cookiecutter-4'}"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15254,7 +15254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 85,
    "id": "f484b678-8001-49bb-97d8-569fc4f8fdd2",
    "metadata": {},
    "outputs": [
@@ -15264,7 +15264,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/bugsinpy-from-repo/'"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15275,7 +15275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 86,
    "id": "773c96b2-8c4b-4e10-adaf-e26801cc3cf2",
    "metadata": {
     "scrolled": true
@@ -15371,7 +15371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 87,
    "id": "6f776d5a-5d68-4af5-a733-11598fba8dd8",
    "metadata": {
     "scrolled": true
@@ -15427,7 +15427,7 @@
        "  'annotation': 'bug(fix)'}]"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15438,7 +15438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 88,
    "id": "49bbe5b6-49dc-4685-aafa-f0df20cead10",
    "metadata": {},
    "outputs": [
@@ -15655,7 +15655,7 @@
        "[19890 rows x 9 columns]"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15675,7 +15675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 89,
    "id": "1f396ca7-a5ea-43df-b6e7-e61ac24d82a7",
    "metadata": {},
    "outputs": [
@@ -15685,7 +15685,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/hapy_bip-from-repo'"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15696,7 +15696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 90,
    "id": "e950fd34-fc63-42cf-bd35-67367e436a86",
    "metadata": {},
    "outputs": [
@@ -15746,7 +15746,7 @@
        "  'annotation': 'bug(fix)'}]"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15802,7 +15802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 91,
    "id": "91643372-cad0-4528-9c03-49456bba1e74",
    "metadata": {},
    "outputs": [
@@ -16019,7 +16019,7 @@
        "[19890 rows x 9 columns]"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16031,7 +16031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 92,
    "id": "efc21569-d013-4f22-8d8d-ece540c832d9",
    "metadata": {},
    "outputs": [
@@ -16045,7 +16045,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16064,7 +16064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 93,
    "id": "f6ee6919-271e-4a84-85ed-aca24a94572d",
    "metadata": {},
    "outputs": [
@@ -16074,7 +16074,7 @@
        "'/mnt/data/python-diff-annotator/example_annotations/HaPy-Bug_bip/bugsinpy-dataset'"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16086,7 +16086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 94,
    "id": "38abed93-188a-4282-8da0-dc89062f634b",
    "metadata": {
     "scrolled": true
@@ -16650,7 +16650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 95,
    "id": "6ab60bf7-c64f-4821-8e93-782383655d88",
    "metadata": {},
    "outputs": [
@@ -16677,7 +16677,7 @@
        "  'annotation': 'bug(fix)'}]"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16688,7 +16688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 96,
    "id": "bb78bc40-7e7d-4d2f-9c58-6c05bb180d98",
    "metadata": {},
    "outputs": [
@@ -16905,7 +16905,7 @@
        "[20268 rows x 9 columns]"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16917,7 +16917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 97,
    "id": "511a1d2a-a127-481a-a424-ee973201f7d7",
    "metadata": {},
    "outputs": [
@@ -16931,7 +16931,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16950,7 +16950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 98,
    "id": "e052c8c0-df6e-44aa-bf3f-7749d7d5462e",
    "metadata": {},
    "outputs": [
@@ -17208,7 +17208,7 @@
        "[195965 rows x 11 columns]"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17219,7 +17219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 99,
    "id": "0472926e-e65d-4dbf-8dd7-6ba6b817874d",
    "metadata": {},
    "outputs": [
@@ -17233,7 +17233,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17244,7 +17244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 100,
    "id": "09a46ed5-25a2-4652-a276-7d4f3b93c8c7",
    "metadata": {},
    "outputs": [
@@ -17502,7 +17502,7 @@
        "[60194 rows x 11 columns]"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17514,7 +17514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 101,
    "id": "c41a3d7b-9132-4462-b5d6-5755a7aaf429",
    "metadata": {},
    "outputs": [
@@ -17645,7 +17645,7 @@
        "16418         test   afterChange    51           test  "
       ]
      },
-     "execution_count": 102,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17657,7 +17657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 102,
    "id": "ecf309c1-4f94-4e3f-9d17-2e0a3a7d07b0",
    "metadata": {},
    "outputs": [
@@ -17768,7 +17768,7 @@
        "4  httpie/downloads.py    programming   afterChange   139       bug(fix)  "
       ]
      },
-     "execution_count": 103,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17788,7 +17788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 103,
    "id": "5472a07a-c2be-4f20-a265-8fa1afeeaa1a",
    "metadata": {},
    "outputs": [
@@ -17942,7 +17942,7 @@
        "4                bug(fix)        bug(fix)     False           False  "
       ]
      },
-     "execution_count": 104,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17968,7 +17968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 104,
    "id": "49445847-888b-4859-a042-3beb9e8c55b7",
    "metadata": {},
    "outputs": [
@@ -17982,7 +17982,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -17993,7 +17993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 105,
    "id": "a32355ba-504e-41ca-8ba1-1fcd8e51cadd",
    "metadata": {},
    "outputs": [
@@ -18008,7 +18008,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18019,7 +18019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 106,
    "id": "ee4d99fb-1eba-4490-b0fa-077c21f0af59",
    "metadata": {},
    "outputs": [
@@ -18032,7 +18032,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18043,7 +18043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 107,
    "id": "f84437f0-d715-4197-bdf0-6de3652aa819",
    "metadata": {},
    "outputs": [
@@ -18056,7 +18056,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18083,7 +18083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 108,
    "id": "80ff15f7-335e-41a9-be0c-38063c47b3e3",
    "metadata": {},
    "outputs": [
@@ -18093,7 +18093,7 @@
        "(60405, 15)"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18104,7 +18104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 109,
    "id": "79ba8b00-144d-48bb-b410-41e52dc2fbb9",
    "metadata": {},
    "outputs": [
@@ -18114,7 +18114,7 @@
        "np.int64(60405)"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18125,7 +18125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 110,
    "id": "7f733a1b-6029-4775-aa0d-4c8c4052b8ca",
    "metadata": {},
    "outputs": [
@@ -18138,7 +18138,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18157,7 +18157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 111,
    "id": "ca0508db-1d21-4ebd-a74a-e6ed8405c83b",
    "metadata": {},
    "outputs": [
@@ -18175,7 +18175,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18186,7 +18186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 112,
    "id": "71ee3ccf-a3bd-4183-9ea9-d664070d3abe",
    "metadata": {},
    "outputs": [
@@ -18204,7 +18204,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18223,7 +18223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 113,
    "id": "aed2ba0f-c6c9-42f9-93ad-30f4156f409a",
    "metadata": {},
    "outputs": [
@@ -18428,7 +18428,7 @@
        "[750 rows x 8 columns]"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18444,7 +18444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 114,
    "id": "cdbde1b9-7ce9-4371-bc2c-4d6da95191b8",
    "metadata": {},
    "outputs": [
@@ -18458,7 +18458,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18469,7 +18469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 115,
    "id": "85a64702-ab38-4e63-b4de-f0e8fedaee30",
    "metadata": {},
    "outputs": [
@@ -18698,7 +18698,7 @@
        "35927   documentation            test  "
       ]
      },
-     "execution_count": 116,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18718,7 +18718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 116,
    "id": "8e13f5d0-3b8d-471c-9d0b-a85c090c6f93",
    "metadata": {},
    "outputs": [
@@ -18765,7 +18765,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18776,7 +18776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 117,
    "id": "7cf9c312-7922-4608-8d0f-67775a0ecc0a",
    "metadata": {},
    "outputs": [
@@ -18786,7 +18786,7 @@
        "0.00019865905140302955"
       ]
      },
-     "execution_count": 118,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18797,7 +18797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 118,
    "id": "55ff4221-2480-4aa2-9553-cb7b3603830f",
    "metadata": {},
    "outputs": [
@@ -18835,26 +18835,26 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>494</th>\n",
-       "      <td>ansible-10</td>\n",
-       "      <td>B_4_15</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
-       "      <td>test/units/modules/system/test_pamd.py</td>\n",
+       "      <th>27695</th>\n",
+       "      <td>pandas-113</td>\n",
+       "      <td>C_6_7</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>8705aad961dd227d38ff93a39697547b98109c9d</td>\n",
+       "      <td>pandas/conftest.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>138</td>\n",
+       "      <td>674</td>\n",
        "      <td>documentation</td>\n",
        "      <td>test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>491</th>\n",
-       "      <td>ansible-10</td>\n",
-       "      <td>B_4_15</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
-       "      <td>test/units/modules/system/test_pamd.py</td>\n",
+       "      <th>27686</th>\n",
+       "      <td>pandas-113</td>\n",
+       "      <td>C_6_7</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>8705aad961dd227d38ff93a39697547b98109c9d</td>\n",
+       "      <td>pandas/conftest.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>137</td>\n",
+       "      <td>671</td>\n",
        "      <td>documentation</td>\n",
        "      <td>test</td>\n",
        "    </tr>\n",
@@ -18871,14 +18871,14 @@
        "      <td>test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>500</th>\n",
-       "      <td>ansible-10</td>\n",
-       "      <td>B_4_15</td>\n",
-       "      <td>U1</td>\n",
-       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
-       "      <td>test/units/modules/system/test_pamd.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>140</td>\n",
+       "      <th>35927</th>\n",
+       "      <td>pandas-19</td>\n",
+       "      <td>C_3_10</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>c6a1638bcd99df677a8f76f036c0b30027eb243c</td>\n",
+       "      <td>pandas/tests/indexing/multiindex/test_loc.py</td>\n",
+       "      <td>beforeChange</td>\n",
+       "      <td>299</td>\n",
        "      <td>documentation</td>\n",
        "      <td>test</td>\n",
        "    </tr>\n",
@@ -18888,25 +18888,25 @@
       ],
       "text/plain": [
        "              bug  bundle user                                       sha  \\\n",
-       "494    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
-       "491    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "27695  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
+       "27686  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
        "27692  pandas-113   C_6_7   U2  8705aad961dd227d38ff93a39697547b98109c9d   \n",
-       "500    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "35927   pandas-19  C_3_10   U2  c6a1638bcd99df677a8f76f036c0b30027eb243c   \n",
        "\n",
-       "                                         file        image  line  \\\n",
-       "494    test/units/modules/system/test_pamd.py  afterChange   138   \n",
-       "491    test/units/modules/system/test_pamd.py  afterChange   137   \n",
-       "27692                      pandas/conftest.py  afterChange   673   \n",
-       "500    test/units/modules/system/test_pamd.py  afterChange   140   \n",
+       "                                               file         image  line  \\\n",
+       "27695                            pandas/conftest.py   afterChange   674   \n",
+       "27686                            pandas/conftest.py   afterChange   671   \n",
+       "27692                            pandas/conftest.py   afterChange   673   \n",
+       "35927  pandas/tests/indexing/multiindex/test_loc.py  beforeChange   299   \n",
        "\n",
        "      annotation_hapy annotation_auto  \n",
-       "494     documentation            test  \n",
-       "491     documentation            test  \n",
+       "27695   documentation            test  \n",
+       "27686   documentation            test  \n",
        "27692   documentation            test  \n",
-       "500     documentation            test  "
+       "35927   documentation            test  "
       ]
      },
-     "execution_count": 119,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -18939,7 +18939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 119,
    "id": "4ea383bf-ca19-45f3-aecb-544ceca86c48",
    "metadata": {},
    "outputs": [
@@ -19228,7 +19228,7 @@
        "46003        bug(fix)  "
       ]
      },
-     "execution_count": 120,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19248,7 +19248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 120,
    "id": "903cbddf-ce60-44b4-b2ea-77992302bf8f",
    "metadata": {},
    "outputs": [
@@ -19258,7 +19258,7 @@
        "0.0002648787352040394"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19269,7 +19269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 121,
    "id": "f23c439d-d1ea-4f68-a472-252c7d9a9d6c",
    "metadata": {},
    "outputs": [
@@ -19307,6 +19307,30 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
+       "      <th>7721</th>\n",
+       "      <td>cookiecutter-4</td>\n",
+       "      <td>C_6_7</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>457a1a4e862aab4102b644ff1d2b2e2b5a766b3c</td>\n",
+       "      <td>cookiecutter/exceptions.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>84</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46003</th>\n",
+       "      <td>pandas-91</td>\n",
+       "      <td>D_3_4</td>\n",
+       "      <td>U3</td>\n",
+       "      <td>cb9a1c7d0319c34a97247973ca96af53ead8033a</td>\n",
+       "      <td>pandas/core/indexes/timedeltas.py</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>374</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>bug(fix)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>13912</th>\n",
        "      <td>keras-11</td>\n",
        "      <td>C_6_7</td>\n",
@@ -19315,30 +19339,6 @@
        "      <td>keras/engine/training_utils.py</td>\n",
        "      <td>afterChange</td>\n",
        "      <td>594</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3793</th>\n",
-       "      <td>black-15</td>\n",
-       "      <td>D_6_1</td>\n",
-       "      <td>U3</td>\n",
-       "      <td>df2ae3bbe6c45298aabb6c04e85cb353205626f1</td>\n",
-       "      <td>black.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>2567</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>bug(fix)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13909</th>\n",
-       "      <td>keras-11</td>\n",
-       "      <td>C_6_7</td>\n",
-       "      <td>U2</td>\n",
-       "      <td>d6b5c5ebb410e3366c9d7aca41977a60134bfe10</td>\n",
-       "      <td>keras/engine/training_utils.py</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>593</td>\n",
        "      <td>documentation</td>\n",
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
@@ -19355,14 +19355,14 @@
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7724</th>\n",
-       "      <td>cookiecutter-4</td>\n",
-       "      <td>C_6_7</td>\n",
+       "      <th>45593</th>\n",
+       "      <td>pandas-90</td>\n",
+       "      <td>C_3_10</td>\n",
        "      <td>U2</td>\n",
-       "      <td>457a1a4e862aab4102b644ff1d2b2e2b5a766b3c</td>\n",
-       "      <td>cookiecutter/exceptions.py</td>\n",
+       "      <td>1c3d64bae7c07b5ae1be337e0ebd751385b7ce27</td>\n",
+       "      <td>pandas/io/pickle.py</td>\n",
        "      <td>afterChange</td>\n",
-       "      <td>85</td>\n",
+       "      <td>167</td>\n",
        "      <td>documentation</td>\n",
        "      <td>bug(fix)</td>\n",
        "    </tr>\n",
@@ -19372,28 +19372,28 @@
       ],
       "text/plain": [
        "                  bug  bundle user                                       sha  \\\n",
+       "7721   cookiecutter-4   C_6_7   U2  457a1a4e862aab4102b644ff1d2b2e2b5a766b3c   \n",
+       "46003       pandas-91   D_3_4   U3  cb9a1c7d0319c34a97247973ca96af53ead8033a   \n",
        "13912        keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
-       "3793         black-15   D_6_1   U3  df2ae3bbe6c45298aabb6c04e85cb353205626f1   \n",
-       "13909        keras-11   C_6_7   U2  d6b5c5ebb410e3366c9d7aca41977a60134bfe10   \n",
        "45599       pandas-90  C_3_10   U2  1c3d64bae7c07b5ae1be337e0ebd751385b7ce27   \n",
-       "7724   cookiecutter-4   C_6_7   U2  457a1a4e862aab4102b644ff1d2b2e2b5a766b3c   \n",
+       "45593       pandas-90  C_3_10   U2  1c3d64bae7c07b5ae1be337e0ebd751385b7ce27   \n",
        "\n",
-       "                                 file        image  line annotation_hapy  \\\n",
-       "13912  keras/engine/training_utils.py  afterChange   594   documentation   \n",
-       "3793                         black.py  afterChange  2567   documentation   \n",
-       "13909  keras/engine/training_utils.py  afterChange   593   documentation   \n",
-       "45599             pandas/io/pickle.py  afterChange   169   documentation   \n",
-       "7724       cookiecutter/exceptions.py  afterChange    85   documentation   \n",
+       "                                    file        image  line annotation_hapy  \\\n",
+       "7721          cookiecutter/exceptions.py  afterChange    84   documentation   \n",
+       "46003  pandas/core/indexes/timedeltas.py  afterChange   374   documentation   \n",
+       "13912     keras/engine/training_utils.py  afterChange   594   documentation   \n",
+       "45599                pandas/io/pickle.py  afterChange   169   documentation   \n",
+       "45593                pandas/io/pickle.py  afterChange   167   documentation   \n",
        "\n",
        "      annotation_auto  \n",
+       "7721         bug(fix)  \n",
+       "46003        bug(fix)  \n",
        "13912        bug(fix)  \n",
-       "3793         bug(fix)  \n",
-       "13909        bug(fix)  \n",
        "45599        bug(fix)  \n",
-       "7724         bug(fix)  "
+       "45593        bug(fix)  "
       ]
      },
-     "execution_count": 122,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19416,7 +19416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 122,
    "id": "85b04f2f-77ed-40c7-b9a5-091eae5071ec",
    "metadata": {},
    "outputs": [
@@ -19432,7 +19432,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19443,7 +19443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 123,
    "id": "73a487a9-c04f-4802-a81d-72c896d874eb",
    "metadata": {},
    "outputs": [
@@ -19566,7 +19566,7 @@
        "56651             both     False            True  "
       ]
      },
-     "execution_count": 124,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19577,7 +19577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 124,
    "id": "f662ae85-66d7-4b47-a491-1d736fad86e4",
    "metadata": {},
    "outputs": [
@@ -19892,7 +19892,7 @@
        "[87 rows x 15 columns]"
       ]
      },
-     "execution_count": 125,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19911,7 +19911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 125,
    "id": "74e45c32-63b1-4f07-a74f-cfd653df1ad0",
    "metadata": {},
    "outputs": [
@@ -19929,7 +19929,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19940,7 +19940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 126,
    "id": "f7acb690-8b6d-411f-9fbd-1b34e231988c",
    "metadata": {},
    "outputs": [
@@ -19956,7 +19956,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -19998,7 +19998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 127,
    "id": "a41f6224-fbc4-4b99-b4b3-eda3970819bd",
    "metadata": {},
    "outputs": [
@@ -20015,7 +20015,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 128,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20034,7 +20034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 128,
    "id": "ca1273ae-4edd-4666-aefa-671e0d8f79ea",
    "metadata": {},
    "outputs": [
@@ -20292,7 +20292,7 @@
        "56843            True  "
       ]
      },
-     "execution_count": 129,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20312,7 +20312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 129,
    "id": "3c4807c0-7e25-42e5-952a-89265872f6e1",
    "metadata": {},
    "outputs": [
@@ -20529,7 +20529,7 @@
        "[77 rows x 9 columns]"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20544,7 +20544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 130,
    "id": "d2ef0a92-815e-44a5-9ec2-7a7399f8f2fe",
    "metadata": {},
    "outputs": [
@@ -20582,48 +20582,12 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1729</th>\n",
-       "      <td>ansible-4</td>\n",
-       "      <td>D_2_5</td>\n",
-       "      <td>U3</td>\n",
-       "      <td>18a66e291dad71128a32d662aa808213acefe0e9</td>\n",
-       "      <td>changelogs/fragments/68723-force-static-collec...</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>2</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>data</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>905</th>\n",
-       "      <td>ansible-13</td>\n",
-       "      <td>A_3_22</td>\n",
-       "      <td>E3</td>\n",
-       "      <td>694ef5660d45fcb97c9beea5b2750f6eadcf5e93</td>\n",
-       "      <td>changelogs/fragments/collection-install-url.yaml</td>\n",
-       "      <td>afterChange</td>\n",
-       "      <td>1</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>data</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>56840</th>\n",
-       "      <td>tornado-3</td>\n",
-       "      <td>A_5_20</td>\n",
-       "      <td>E2</td>\n",
-       "      <td>aa622e724f80e0f7fcee369f75d69d1db13d72f2</td>\n",
-       "      <td>.travis.yml</td>\n",
-       "      <td>beforeChange</td>\n",
-       "      <td>87</td>\n",
-       "      <td>documentation</td>\n",
-       "      <td>data</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>468</th>\n",
-       "      <td>ansible-10</td>\n",
-       "      <td>A_2_23</td>\n",
-       "      <td>E2</td>\n",
-       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
-       "      <td>changelogs/fragments/66398-pamd_fix-attributee...</td>\n",
+       "      <th>2767</th>\n",
+       "      <td>ansible-9</td>\n",
+       "      <td>C_4_9</td>\n",
+       "      <td>U2</td>\n",
+       "      <td>6f1bb37feb81acd99157f5ba0933fecd747015a2</td>\n",
+       "      <td>changelogs/fragments/66807-redhat_subscription...</td>\n",
        "      <td>afterChange</td>\n",
        "      <td>1</td>\n",
        "      <td>documentation</td>\n",
@@ -20642,12 +20606,48 @@
        "      <td>data</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1309</th>\n",
-       "      <td>ansible-17</td>\n",
-       "      <td>B_1_18</td>\n",
+       "      <th>1732</th>\n",
+       "      <td>ansible-4</td>\n",
+       "      <td>D_2_5</td>\n",
+       "      <td>U3</td>\n",
+       "      <td>18a66e291dad71128a32d662aa808213acefe0e9</td>\n",
+       "      <td>changelogs/fragments/68723-force-static-collec...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>3</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>470</th>\n",
+       "      <td>ansible-10</td>\n",
+       "      <td>B_4_15</td>\n",
        "      <td>U1</td>\n",
-       "      <td>b38cb37728df76e0529243bdce694b18ca0e1163</td>\n",
-       "      <td>changelogs/fragments/mount-facts-octal-escapes...</td>\n",
+       "      <td>a4b59d021368285490f7cda50c11ac4f7a8030b5</td>\n",
+       "      <td>changelogs/fragments/66398-pamd_fix-attributee...</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>1</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18680</th>\n",
+       "      <td>keras-43</td>\n",
+       "      <td>B_3_16</td>\n",
+       "      <td>U1</td>\n",
+       "      <td>b17169ca5d6cd1c8aeb237fc2bb0555c9e1b6a02</td>\n",
+       "      <td>docs/mkdocs.yml</td>\n",
+       "      <td>afterChange</td>\n",
+       "      <td>2</td>\n",
+       "      <td>documentation</td>\n",
+       "      <td>data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2768</th>\n",
+       "      <td>ansible-9</td>\n",
+       "      <td>D_2_5</td>\n",
+       "      <td>U3</td>\n",
+       "      <td>6f1bb37feb81acd99157f5ba0933fecd747015a2</td>\n",
+       "      <td>changelogs/fragments/66807-redhat_subscription...</td>\n",
        "      <td>afterChange</td>\n",
        "      <td>1</td>\n",
        "      <td>documentation</td>\n",
@@ -20659,31 +20659,31 @@
       ],
       "text/plain": [
        "              bug  bundle user                                       sha  \\\n",
-       "1729    ansible-4   D_2_5   U3  18a66e291dad71128a32d662aa808213acefe0e9   \n",
-       "905    ansible-13  A_3_22   E3  694ef5660d45fcb97c9beea5b2750f6eadcf5e93   \n",
-       "56840   tornado-3  A_5_20   E2  aa622e724f80e0f7fcee369f75d69d1db13d72f2   \n",
-       "468    ansible-10  A_2_23   E2  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "2767    ansible-9   C_4_9   U2  6f1bb37feb81acd99157f5ba0933fecd747015a2   \n",
        "715    ansible-12   D_5_2   U3  2fa8f9cfd80daf32c7d222190edf7cfc7234582a   \n",
-       "1309   ansible-17  B_1_18   U1  b38cb37728df76e0529243bdce694b18ca0e1163   \n",
+       "1732    ansible-4   D_2_5   U3  18a66e291dad71128a32d662aa808213acefe0e9   \n",
+       "470    ansible-10  B_4_15   U1  a4b59d021368285490f7cda50c11ac4f7a8030b5   \n",
+       "18680    keras-43  B_3_16   U1  b17169ca5d6cd1c8aeb237fc2bb0555c9e1b6a02   \n",
+       "2768    ansible-9   D_2_5   U3  6f1bb37feb81acd99157f5ba0933fecd747015a2   \n",
        "\n",
-       "                                                    file         image  line  \\\n",
-       "1729   changelogs/fragments/68723-force-static-collec...   afterChange     2   \n",
-       "905     changelogs/fragments/collection-install-url.yaml   afterChange     1   \n",
-       "56840                                        .travis.yml  beforeChange    87   \n",
-       "468    changelogs/fragments/66398-pamd_fix-attributee...   afterChange     1   \n",
-       "715    changelogs/fragments/65541-fix-utf8-issue-env-...   afterChange     2   \n",
-       "1309   changelogs/fragments/mount-facts-octal-escapes...   afterChange     1   \n",
+       "                                                    file        image  line  \\\n",
+       "2767   changelogs/fragments/66807-redhat_subscription...  afterChange     1   \n",
+       "715    changelogs/fragments/65541-fix-utf8-issue-env-...  afterChange     2   \n",
+       "1732   changelogs/fragments/68723-force-static-collec...  afterChange     3   \n",
+       "470    changelogs/fragments/66398-pamd_fix-attributee...  afterChange     1   \n",
+       "18680                                    docs/mkdocs.yml  afterChange     2   \n",
+       "2768   changelogs/fragments/66807-redhat_subscription...  afterChange     1   \n",
        "\n",
        "      annotation_hapy annotation_auto  \n",
-       "1729    documentation            data  \n",
-       "905     documentation            data  \n",
-       "56840   documentation            data  \n",
-       "468     documentation            data  \n",
+       "2767    documentation            data  \n",
        "715     documentation            data  \n",
-       "1309    documentation            data  "
+       "1732    documentation            data  \n",
+       "470     documentation            data  \n",
+       "18680   documentation            data  \n",
+       "2768    documentation            data  "
       ]
      },
-     "execution_count": 131,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20698,7 +20698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 131,
    "id": "7181a32b-eced-4c99-9146-21ad84c8ea80",
    "metadata": {},
    "outputs": [
@@ -20852,7 +20852,7 @@
        "4                bug(fix)        bug(fix)     False           False  "
       ]
      },
-     "execution_count": 132,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20874,7 +20874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 132,
    "id": "97ea4c1d-e95d-4700-a372-680a1cfe8bdd",
    "metadata": {},
    "outputs": [
@@ -20887,7 +20887,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20898,7 +20898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 133,
    "id": "62009f45-4767-4690-8cc6-a3c04007741e",
    "metadata": {},
    "outputs": [
@@ -20911,7 +20911,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20938,7 +20938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 134,
    "id": "5fe7d5f7-c22e-4129-8b40-a3cadb16fdb0",
    "metadata": {},
    "outputs": [
@@ -20955,7 +20955,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20967,7 +20967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 135,
    "id": "a3e28313-ff8d-4253-b42c-541b6c7b46dd",
    "metadata": {},
    "outputs": [
@@ -20977,7 +20977,7 @@
        "['U2', 'U3', 'U1', 'E2', 'E3', 'E1']"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -20989,7 +20989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 136,
    "id": "b25ba619-7378-4462-b396-ff4b9041642e",
    "metadata": {},
    "outputs": [
@@ -21206,7 +21206,7 @@
        "[1787 rows x 9 columns]"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21222,7 +21222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 137,
    "id": "466dfed0-d537-4c17-ad1a-fd68840e8bca",
    "metadata": {},
    "outputs": [
@@ -21232,7 +21232,7 @@
        "(14874, 15)"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21243,7 +21243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 138,
    "id": "d2e35c0a-d94d-4cce-ba11-d43f06ae382c",
    "metadata": {},
    "outputs": [
@@ -21256,7 +21256,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21267,7 +21267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 139,
    "id": "06f5e3d0-7016-4d62-a117-2355d1bbb85a",
    "metadata": {},
    "outputs": [
@@ -21295,7 +21295,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21306,7 +21306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 140,
    "id": "7f30c08a-ed1c-4c6a-8c71-d08407dada0e",
    "metadata": {},
    "outputs": [
@@ -21316,7 +21316,7 @@
        "np.float64(0.0700551297566223)"
       ]
      },
-     "execution_count": 141,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21328,7 +21328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 141,
    "id": "1edfe252-d79d-4478-b2ce-38566cf9fb36",
    "metadata": {},
    "outputs": [
@@ -21341,7 +21341,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 142,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21352,7 +21352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 142,
    "id": "26aa92f4-e848-4fbe-9292-0ebf221c7911",
    "metadata": {},
    "outputs": [
@@ -21362,7 +21362,7 @@
        "np.int64(13832)"
       ]
      },
-     "execution_count": 143,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21374,7 +21374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 143,
    "id": "f6768e5d-900b-4e4c-bf16-0b4883beb032",
    "metadata": {},
    "outputs": [
@@ -21387,7 +21387,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 144,
+     "execution_count": 143,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21398,7 +21398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 144,
    "id": "1b8f8ec2-8f86-42c5-9086-177ce7430039",
    "metadata": {},
    "outputs": [
@@ -21420,7 +21420,7 @@
        "Name: count, dtype: float64"
       ]
      },
-     "execution_count": 145,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21457,7 +21457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 145,
    "id": "7ce3bc14-5fff-4f16-ad8e-7b16fc14f349",
    "metadata": {},
    "outputs": [
@@ -21474,7 +21474,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21486,7 +21486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 146,
    "id": "9337b17e-a936-465b-8e6f-f1f83554216d",
    "metadata": {},
    "outputs": [
@@ -21496,7 +21496,7 @@
        "['U2', 'U3', 'U1', 'E2', 'E3', 'E1']"
       ]
      },
-     "execution_count": 147,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21508,7 +21508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 147,
    "id": "ed1b58f4-8f1a-4487-8bb8-55e0bacfcec2",
    "metadata": {},
    "outputs": [],
@@ -21521,7 +21521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 148,
    "id": "b2b5d508-2500-4842-9979-1b997f564a6d",
    "metadata": {},
    "outputs": [],
@@ -21549,7 +21549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 149,
    "id": "6de67c99-447b-4042-b99f-abb3912ddebb",
    "metadata": {},
    "outputs": [
@@ -21559,7 +21559,7 @@
        "(391918, 11)"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21570,7 +21570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 150,
    "id": "8fa64257-63a0-4f80-ba54-16879172d05e",
    "metadata": {},
    "outputs": [
@@ -21580,7 +21580,7 @@
        "(65321.666666666664, 65317.666666666664)"
       ]
      },
-     "execution_count": 151,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21592,7 +21592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 151,
    "id": "1554e983-77f9-4f96-a53d-27193929caad",
    "metadata": {},
    "outputs": [],
@@ -21602,7 +21602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 152,
    "id": "f4c0cb37-ee76-4b39-bfa5-831cdf03931c",
    "metadata": {},
    "outputs": [
@@ -21618,7 +21618,7 @@
        " 'test']"
       ]
      },
-     "execution_count": 153,
+     "execution_count": 152,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21630,7 +21630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 153,
    "id": "b1aaf654-20f9-450b-93dc-a959e72d8163",
    "metadata": {},
    "outputs": [
@@ -21648,7 +21648,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 154,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21659,7 +21659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 154,
    "id": "6e384092-bfbc-49a7-8129-613bccd681c9",
    "metadata": {},
    "outputs": [
@@ -21900,7 +21900,7 @@
        "[145269 rows x 11 columns]"
       ]
      },
-     "execution_count": 155,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -21911,7 +21911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 155,
    "id": "af230d51-4df2-4b32-bcf7-7a3d3bea7b44",
    "metadata": {},
    "outputs": [],
@@ -21933,7 +21933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 156,
    "id": "f2a7b9ab-e071-4cd2-a12c-257b1f33a1ef",
    "metadata": {},
    "outputs": [],
@@ -21950,7 +21950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 157,
    "id": "f0ef57ab-0db8-4008-986a-dad4f6223f46",
    "metadata": {},
    "outputs": [],
@@ -21972,7 +21972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 158,
    "id": "c6d6e631-19a4-4055-a379-8545e858df6c",
    "metadata": {
     "scrolled": true
@@ -36005,7 +36005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 159,
    "id": "2a306642-1b7a-403d-93b2-e83fdf92896e",
    "metadata": {
     "scrolled": true
@@ -36017,7 +36017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 160,
    "id": "021a3e5a-c16f-46f6-a962-3bcf4e0d56f0",
    "metadata": {},
    "outputs": [
@@ -36332,7 +36332,7 @@
        "[145269 rows x 15 columns]"
       ]
      },
-     "execution_count": 161,
+     "execution_count": 160,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -36504,6 +36504,382 @@
    "source": [
     "G.to_csv(\"consensus.csv\")\n",
     "%ls -l -h 'consensus.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "562068b5-0ad7-4489-9985-a14a4cd02a43",
+   "metadata": {},
+   "source": [
+    "#### Per line-type consensus (addition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fe31268-add5-48b0-a4d2-23d3e3f0aab1",
+   "metadata": {},
+   "source": [
+    "Compute per-line consensus using **aggregated per-line data** rather than per-user data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "id": "de7d052f-1bf7-462d-b41c-7c51b7a5e972",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['ds', 'id', 'file', 'image', 'line', 'annotation_U1', 'annotation_U2',\n",
+       "       'annotation_U3', 'annotation_E1', 'annotation_E2', 'annotation_E3',\n",
+       "       'most_common', 'common_count', 'n_reviewers', 'consensus'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "32813383-286a-43bd-b76b-4e010d9a746b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ds               object\n",
+       "id               object\n",
+       "file             object\n",
+       "image            object\n",
+       "line              int64\n",
+       "annotation_U1    object\n",
+       "annotation_U2    object\n",
+       "annotation_U3    object\n",
+       "annotation_E1    object\n",
+       "annotation_E2    object\n",
+       "annotation_E3    object\n",
+       "most_common      object\n",
+       "common_count      int64\n",
+       "n_reviewers       int64\n",
+       "consensus        object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "id": "62077bf9-ffa8-4cad-892f-6dde3563c51f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ds\n",
+       "crawl         91746\n",
+       "cve           33302\n",
+       "bugs-in-py    20221\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 162,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G['ds'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "id": "95d201c4-26e2-4fab-9a78-bc94e4ec3daa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      63294\n",
+       "documentation             41217\n",
+       "bug(fix)                  33870\n",
+       "refactoring                1610\n",
+       "test + refactoring          966\n",
+       "bug(fix) + refactoring      674\n",
+       "other                       230\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 164,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "id": "2afc2417-5eb2-473a-86a7-d156127f1bc9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(145269, 15)"
+      ]
+     },
+     "execution_count": 165,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "id": "6a017736-6733-4ff1-829b-04ec6f1cd3f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(141861, 15)"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G_consensus = G[~G['consensus'].isna()]\n",
+    "G_consensus.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "b1a4c87c-6cc5-46ce-8aee-bca695f0418e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9765400739318093"
+      ]
+     },
+     "execution_count": 167,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G_consensus.shape[0]/G.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "679ad4c0-79f0-419f-ba8c-d66b794ea8a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      63294\n",
+       "documentation             41217\n",
+       "bug(fix)                  33870\n",
+       "refactoring                1610\n",
+       "test + refactoring          966\n",
+       "bug(fix) + refactoring      674\n",
+       "other                       230\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G_consensus['consensus'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "30c58b84-a376-4572-b18b-737da70ff86c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "most_common\n",
+       "test                      63294\n",
+       "documentation             41584\n",
+       "bug(fix)                  36015\n",
+       "refactoring                2195\n",
+       "test + refactoring         1055\n",
+       "bug(fix) + refactoring      867\n",
+       "other                       259\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 169,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "G['most_common'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "317bca6e-9028-4ba8-a874-8154cf65d046",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "consensus\n",
+       "test                      1.000000\n",
+       "documentation             0.991174\n",
+       "bug(fix)                  0.940441\n",
+       "refactoring               0.733485\n",
+       "test + refactoring        0.915640\n",
+       "bug(fix) + refactoring    0.777393\n",
+       "other                     0.888031\n",
+       "Name: count, dtype: float64"
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#G['most_common'].value_counts()/G_consensus['consensus'].value_counts()\n",
+    "G_consensus['consensus'].value_counts()/G['most_common'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b0a7ecf-e105-4c70-9762-6c1e89997bc6",
+   "metadata": {},
+   "source": [
+    "Embedding consensus into Sankey flow diagram comparing automatic and manual annotations:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ff622a7-8c4c-423f-ad91-463e77bb1774",
+   "metadata": {},
+   "source": [
+    "- original plot from `00-HaPy_Bug-Paper.ipynb`, from the \"Flow\" section\n",
+    "\n",
+    "```mermaid\n",
+    "---\n",
+    "config:\n",
+    "  sankey:\n",
+    "    showValues: true\n",
+    "---\n",
+    "sankey-beta\n",
+    "\n",
+    "%% Taken from `notebooks/experiments/00-HaPy_Bug-Paper.ipynb`\n",
+    "%% in https://github.com/ncusi/PatchScope\n",
+    "\n",
+    "%% auto,user,S\n",
+    "A: bug(fix),U: bug(fix),26.403257057366396\n",
+    "A: bug(fix),U: bug(fix) + refactoring,2.2848453633531998\n",
+    "A: bug(fix),U: documentation,3.2967895420989377\n",
+    "A: bug(fix),U: other,0.8265273587913571\n",
+    "A: bug(fix),U: refactoring,3.303166311039168\n",
+    "A: bug(fix),U: test,0.06082456527604052\n",
+    "A: documentation,U: bug(fix),0.2972555367522625\n",
+    "A: documentation,U: bug(fix) + refactoring,0.006867289627940059\n",
+    "A: documentation,U: documentation,14.887793392686335\n",
+    "A: documentation,U: other,0.11919652711353101\n",
+    "A: documentation,U: refactoring,0.026488117136340226\n",
+    "A: documentation,U: test,0.009319893066490078\n",
+    "A: documentation,U: test + refactoring,0.004414686189390038\n",
+    "A: test,U: bug(fix),0.0941799720403208\n",
+    "A: test,U: bug(fix) + refactoring,0.00833885169107007\n",
+    "A: test,U: documentation,1.4499791528707724\n",
+    "A: test,U: other,0.03924165501680033\n",
+    "A: test,U: refactoring,0.8363377725455571\n",
+    "A: test,U: test,44.620214357540526\n",
+    "A: test,U: test + refactoring,1.4249625977975622\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "833d6885-5a44-4229-8a7c-3d0d07f7c57e",
+   "metadata": {},
+   "source": [
+    "- as above, but with consensus percentages added\n",
+    "\n",
+    "```mermaid\n",
+    "---\n",
+    "config:\n",
+    "  sankey:\n",
+    "    showValues: true\n",
+    "---\n",
+    "sankey-beta\n",
+    "\n",
+    "%% Taken from `notebooks/experiments/00-HaPy_Bug-Paper.ipynb`\n",
+    "%% in https://github.com/ncusi/PatchScope\n",
+    "\n",
+    "%% auto,user,S\n",
+    "A: bug(fix),U: bug(fix) [94.1%],26.403257057366396\n",
+    "A: bug(fix),U: bug(fix) + refactoring [77.7%],2.2848453633531998\n",
+    "A: bug(fix),U: documentation [99.1%],3.2967895420989377\n",
+    "A: bug(fix),U: other [88.8%],0.8265273587913571\n",
+    "A: bug(fix),U: refactoring [73.3%],3.303166311039168\n",
+    "A: bug(fix),U: test [100.0%],0.06082456527604052\n",
+    "A: documentation,U: bug(fix) [94.1%],0.2972555367522625\n",
+    "A: documentation,U: bug(fix) + refactoring [77.7%],0.006867289627940059\n",
+    "A: documentation,U: documentation [99.1%],14.887793392686335\n",
+    "A: documentation,U: other [88.8%],0.11919652711353101\n",
+    "A: documentation,U: refactoring [73.3%],0.026488117136340226\n",
+    "A: documentation,U: test [100.0%],0.009319893066490078\n",
+    "A: documentation,U: test + refactoring [91.6%],0.004414686189390038\n",
+    "A: test,U: bug(fix) [94.1%],0.0941799720403208\n",
+    "A: test,U: bug(fix) + refactoring [77.7%],0.00833885169107007\n",
+    "A: test,U: documentation [99.1%],1.4499791528707724\n",
+    "A: test,U: other [88.8%],0.03924165501680033\n",
+    "A: test,U: refactoring [73.3%],0.8363377725455571\n",
+    "A: test,U: test [100.0%],44.620214357540526\n",
+    "A: test,U: test + refactoring [91.6%],1.4249625977975622\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -55612,7 +55988,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This section was added to address the response from reviewer \#103C for the _"HaPy-Bug – Human Annotated Python Bug
Resolution Dataset"_ paper, which was submitted (and accepted) to the Data and Tool Showcase Track of the MSR'2025 conference.

> The authors report interesting results, indicating that only a small proportion of lines (≤ 6%) required manual intervention after automatic annotations. More details on the nature of these modifications would strengthen the analysis. Specifically, it would be helpful to know if the automatic annotations were primarily inaccurate in specific categories (e.g., documentation) or whether they lacked context for certain types of code changes. Since the automation relies on simple syntax rules, it might miss complex bug patterns, which requires further discussion.
> 
> The discussion about consensus labels is clear, but a breakdown by label type (bug(fix), test, documentation, etc.) could clarify whether disagreements tend to occur more frequently within specific categories.

The idea was to add percentages of line labels for which there is consensus to the Sankey diagram on Figure 2(b) in the mentioned paper; however I could not find the code that was used to create said diagram, and/or run said code from Jupyter Notebook.

Example diagram (which should have used values, not percentages):

![mermaid-diagram-2025-01-30-234745](https://github.com/user-attachments/assets/d22f2aa7-72a1-4c02-bb84-e48a0d653042)
