### PR TITLE
Packaging - Dockerfile, Procfile, docker.patchscope-web.service, metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.11
 WORKDIR /code
 
 COPY ./requirements.txt /code/requirements.txt
-RUN python3 -m pip install --no-cache-dir --upgrade pip
-RUN python3 -m pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY . .
 RUN python3 -m pip install --no-cache-dir --upgrade .[web]
@@ -20,7 +20,7 @@ CMD ["panel", "serve", \
      "--allow-websocket-origin", "*" \
 ]
 
-RUN mkdir /.cache
-RUN chmod 777 /.cache
-RUN mkdir .chroma
-RUN chmod 777 .chroma
+RUN mkdir /.cache && \
+    chmod 777 /.cache && \
+    mkdir .chroma && \
+    chmod 777 .chroma

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: panel serve --address="0.0.0.0" --port=$PORT src/diffinsights_web/apps/contributors.py src/diffinsights_web/apps/author.py --allow-websocket-origin="patchscope-9d05e7f15fec.herokuapp.com"
+web: panel serve --address="0.0.0.0" --port=$PORT src/diffinsights_web/apps/contributors.py src/diffinsights_web/apps/author.py --index=contributors --reuse-sessions --global-loading-spinner --allow-websocket-origin="patchscope-9d05e7f15fec.herokuapp.com"

--- a/docker.patchscope-web.service
+++ b/docker.patchscope-web.service
@@ -1,0 +1,23 @@
+# based on https://jugmac00.github.io/blog/how-to-run-a-dockerized-service-via-systemd/
+# and https://blog-container--solutions-com.cdn.ampproject.org/v/s/blog.container-solutions.com/running-docker-containers-with-systemd
+
+[Unit]
+Description=PatchScope Web Dashboard
+Documentation=https://ncusi.github.io/PatchScope
+Documentation=https://github.com/ncusi/PatchScope
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+#ExecStartPre=-/usr/bin/docker exec %n stop
+#ExecStartPre=-/usr/bin/docker rm %n
+#ExecStartPre=/usr/bin/docker pull ncusi/patchscope:latest
+ExecStart=/usr/bin/docker run --rm --name %n \
+    -p 22222:7860 \
+    ncusi/patchscope:latest
+
+[Install]
+#WantedBy=default.target
+WantedBy=multi-user.target

--- a/docker.patchscope-web.service
+++ b/docker.patchscope-web.service
@@ -11,12 +11,32 @@ Requires=docker.service
 [Service]
 TimeoutStartSec=0
 Restart=always
-#ExecStartPre=-/usr/bin/docker exec %n stop
-#ExecStartPre=-/usr/bin/docker rm %n
+
+# We cannot have more than one container with the same name so force a cleanup
+# prior to starting a new container.  We do cleanup using a ExecStartPre so
+# that if the service is shutdown, fails, etc, the last container will still
+# exist for examination if needed.  The leading dash ("-") tells systemd to
+# ignore failures.
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+
+# Update Docker image if non-existent or needs updating
 #ExecStartPre=/usr/bin/docker pull ncusi/patchscope:latest
+
+# Run the container.  The -d (detach) or -t (pty) options must NOT be used here.
+# Even better would be to use here 'systemd-docker' instead of 'docker' to have
+# systemd supervise the Docker container instead of the Docker client.
 ExecStart=/usr/bin/docker run --rm --name %n \
     -p 22222:7860 \
     ncusi/patchscope:latest
+
+# Use the Docker stop command to single to a container to stop.
+# Failure is OK here if the container has already crashed.
+ExecStop=-/usr/bin/docker stop %n
+
+# The Docker run command runs for the life of the container
+# and pipes back STDOUT/STDERR to Journald.  No forking.
+Type=simple
 
 [Install]
 #WantedBy=default.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,7 @@ doc = [
   "black~=25.1.0",
 ]
 pylinguist = [
-  "linguist>=0.1.1",
-  # There is more up-to-date version on GitHub (as fork), which does install correctly
-  # but PyPI doesn't allow direct dependencies
-  #"linguist@git+https://github.com/retanoj/linguist#egg=master",
+  "linguist@git+https://github.com/retanoj/linguist#egg=master",
 ]
 examples = [
   "dvc[s3]==3.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,10 @@ doc = [
   "black~=25.1.0",
 ]
 pylinguist = [
-  "linguist@git+https://github.com/retanoj/linguist#egg=master",
+  "linguist>=0.1.1",
+  # There is more up-to-date version on GitHub (as fork), which does install correctly
+  # but PyPI doesn't allow direct dependencies
+  #"linguist@git+https://github.com/retanoj/linguist#egg=master",
 ]
 examples = [
   "dvc[s3]==3.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ keywords = [
   "code-analysis",
 ]
 authors = [
-  {name = "Mikołaj Fejzer", email = "mfejzer@mat.umk.pl"},
   {name = "Jakub Narębski", email = "jnareb@mat.umk.pl"},
+  {name = "Mikołaj Fejzer", email = "mfejzer@mat.umk.pl"},
   {name = "Piotr Przymus", email = "piotr.przymus@mat.umk.pl"},
   {name = "Krzysztof Stencel", email = "stencel@mimuw.edu.pl"}
 ]
 maintainers = [
-  {name = "Mikołaj Fejzer", email = "mfejzer@mat.umk.pl"},
   {name = "Jakub Narębski", email = "jnareb@mat.umk.pl"},
+  {name = "Mikołaj Fejzer", email = "mfejzer@mat.umk.pl"},
   {name = "Piotr Przymus", email = "piotr.przymus@mat.umk.pl"},
   {name = "Krzysztof Stencel", email = "stencel@mimuw.edu.pl"}
 ]
@@ -30,6 +30,10 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Information Technology",
+  "Topic :: Software Development",
 ]
 # panel-mermaid requires Python 3.11
 requires-python = ">= 3.11"  # vermin --eval-annotations --backport typing --backport typing_extensions .
@@ -42,8 +46,9 @@ diff-gather-stats = "diffannotator.gather_data:app"
 diffinsights-web = "diffinsights_web.main:app"
 
 [project.urls]
-bugs = "https://github.com/ncusi/PatchScope/issues"
-homepage = "https://github.com/ncusi/PatchScope"
+repository = "https://github.com/ncusi/PatchScope"
+issues = "https://github.com/ncusi/PatchScope/issues"
+documentation = "https://ncusi.github.io/PatchScope/"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Enhances and expands project metadata in `pyproject.toml`. There also was an attempt to adjust requirements in order to be able to publish PatchScope first to TestPyPI, and then to PyPI - the problem is that `linguist` available from pip does not work when using modern Python, so the change was reverted.

Simplifies `Dockerfile` so that it creates less layers (and thus possibly smaller image). Tested that the image works correctly (well, except for bugs in PatchScope and its web dashboard app). Lightly tested.

Brings `Procfile` (used by Heroku, though there are plans to move this service to more commonly used Dockerfile).

Add `docker.patchscope-web.service` for automatic (re)activation by systemd. Lightly tested,