### PR TITLE
Documentation: Improve process for MkDocs-based documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ directory.
 You can download data for more repos from <https://dagshub.com/ncusi/PatchScope>
 with [DVC][], see the ["Examples and demos"](#examples-and-demos) section below.
 
-There is a web app demo available for those repos at <http://patchscope.mat.umk.pl/>,
+There is a web app demo available for those repos at <https://patchscope.mat.umk.pl/>,
 and also basic [demo on Heroku](https://patchscope-9d05e7f15fec.herokuapp.com/).
 
 The simplest solution to run those demos locally is to clone
@@ -403,7 +403,7 @@ Command line and terminal interface tools:
 - [`statscat`](https://github.com/z1cheng/statscat)
   ![Go](https://img.shields.io/badge/Go-%2300ADD8.svg?logo=Go&logoColor=white)
   is a CLI tool to get statistics of your all git repositories
-- [hxtools](http://inai.de/projects/hxtools/)
+- [hxtools](https://inai.de/projects/hxtools/)
   ![Perl](https://img.shields.io/badge/Perl-%2339457E.svg?logo=Perl&logoColor=white)
   by Jan Engelhardt
   is a collection of small tools and scripts, which include
@@ -441,7 +441,7 @@ Tools to generate HTML dashboard, or providing an interactive web application:
   with [NVD3](https://nvd3.org/)-driven interactive metrics visualisations;<br>
   **note** that demo site <https://repostat.imfast.io/> no longer works
     - [NVD3.js](https://nvd3.org/) is an attempt to build re-usable charts
-      and chart components for [d3.js](http://d3js.org/)
+      and chart components for [d3.js](https://d3js.org/)
 - [Repositorch](https://github.com/kirnosenko/Repositorch)
   is a Git repository analysis engine written in C#;
   it recommends using Docker Compose to install

--- a/docs/annotation_process.md
+++ b/docs/annotation_process.md
@@ -438,12 +438,14 @@ diff-annotate --line-callback <callback_script.py>
 An example of such callback function can be found in `data/experiments/`,
 in the `HaPy-Bug/` subdirectory, as [`hapybug_line_callback_func.py`](../data/experiments/HaPy-Bug/hapybug_line_callback_func.py):
 
+```python
+
 {%
-    include-markdown "../data/experiments/HaPy-Bug/hapybug_line_callback_func.py"
-    start="```python\n"
-    end="```\n"
+    include "../data/experiments/HaPy-Bug/hapybug_line_callback_func.py"
     recursive=false
 %}
+
+```
 
 > Note: actually, the `diff-annotate` script processing the `--line-callback`
 > parameter first checks if it can be interpreted as file name, and if file

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,8 +121,8 @@ plugins:
             show_signature: true
             separate_signature: true
             show_signature_annotations: true
-      watch:  # for `mkdocs serve`, to trigger rebuild
-        - src
+watch:  # for `mkdocs serve`, to trigger rebuild
+  - src
 #extra:
 #  version:
 #    provider: mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ markdown_extensions:
   - toc:  # automatically generate a table of contents
       baselevel: 2
       permalink: true
-      slugify: !!python/name:pymdownx.slugs.uslugify
+      slugify: !!python/object/apply:pymdownx.slugs.slugify { kwds: { case: lower } }
   - meta
 plugins:
   - include-markdown  # including (embedding) Markdown files, by default within {% and %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,8 @@ plugins:
             show_signature: true
             separate_signature: true
             show_signature_annotations: true
+hooks:
+  - scripts/my_hooks.py
 watch:  # for `mkdocs serve`, to trigger rebuild
   - src
 #extra:

--- a/scripts/my_hooks.py
+++ b/scripts/my_hooks.py
@@ -1,0 +1,80 @@
+import logging
+import re
+from pathlib import PurePath
+
+import mkdocs.plugins
+
+log = logging.getLogger('mkdocs')
+
+@mkdocs.plugins.event_priority(-50)
+def on_page_markdown(markdown, page, **kwargs):
+    path = page.file.src_uri
+    changed = 0
+
+    def replace_links(match_obj):
+        nonlocal changed
+
+        include_markdown_reversed = {
+            '../README.md': 'index.md',
+            '../data/examples/README.md': 'examples.md',
+            '../notebooks/README.md': 'notebooks.md',
+            '../notebooks/panel/README.md': 'notebooks.md',
+            '../schema/README.md': 'schema.md',
+            '../src/diffinsights_web/README.md': 'diffinsights_web.md',
+        }
+        fragment: str = ''
+
+        if match_obj.group('hash') is not None:
+            fragment = match_obj.group('hash')
+
+        if match_obj.group('link') and match_obj.group('link').startswith('https://'):
+            # external link
+            #log.info(f"- external link => {match_obj.group('link')}{fragment}")
+            return match_obj.group(0)  # whole match
+        elif not match_obj.group('link') and match_obj.group('hash'):
+            # internal link
+            #log.info(f"- internal link => {match_obj.group('hash')}")
+            return match_obj.group(0)  # whole match
+
+        orig_link = match_obj.group('link')
+        try:
+            rebased_link = PurePath(orig_link).relative_to(PurePath(path))
+        except ValueError:
+            rebased_link = orig_link
+
+        if rebased_link.startswith('../'):
+            if rebased_link in include_markdown_reversed:
+                replacement_link = f"{include_markdown_reversed[rebased_link]}{fragment}"
+            else:
+                replacement_link = f"https://github.com/ncusi/PatchScope/blob/main/{rebased_link[3:]}{fragment}"
+
+            #log.info(f"- inner link => {rebased_link}{match_obj.group('hash') or ''} replaced with {replacement_link}")
+            changed += 1
+            return f"[{match_obj.group('src')}]({replacement_link})"
+        #else:
+        #    log.info(f"- inner link in {path} => {orig_link} -> {rebased_link}")
+
+        return match_obj.group(0)
+
+    if path.startswith('reference/'):
+        return None
+
+    #log.info(f"Processing documentation file '{path}'")
+
+    for m in re.finditer(r'\bhttp://[^)> ]+', markdown):
+        log.warning(f"Documentation file '{path}' contains a non-HTTPS link: {m[0]}")
+
+    replacement = re.sub(
+        pattern=r'\[(?P<src>.*?)\]\((?P<link>.*?)(?P<hash>#[^)]*)?\)',
+        repl=replace_links,
+        string=markdown,
+    )
+
+    if changed:
+        log.info(f"Rewrote {changed:2d} link(s) in documentation file '{path}'")
+        return replacement
+    elif replacement != markdown:  # just in case
+        log.info(f"CHANGED contents of documentation file '{path}'")
+        return replacement
+    else:
+        return None


### PR DESCRIPTION
Fix a few warnings from `mkdocs build` / `mkdocs serve`, namely the use of deprecated 'uslugify' instead of configurable 'slugify', and 'watch' configuration added under 'mkdocstrings' plugin instead of being (as it should) a global option for mkdocs itself.

Fix 'include-markdown' directive in `annotation_process.md` (also replacing it with 'include' directive), so that example line callback function is included properly, inside code block.

Rewrite links in included (via 'include-markdown') README.md Markdown files with custom hook, so that they lead either to documentation page, or to rendering of a file in question in project's GitHub.

While at it, replace HTTP links with HTTPS ones, where possible.